### PR TITLE
^~ include setigen/voltage/*.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include setigen/assets/*
+include setigen/voltage/*.txt


### PR DESCRIPTION
Include the *_template.txt files

```
Traceback (most recent call last):
  File "./gen_raw.py", line 165, in <module>
    rvb.record(raw_file_stem=stem,
  File "/home/sonata/miniconda3/lib/python3.8/site-packages/setigen/voltage/backend.py", line 422, in record
    self._make_header(f, header_dict)
  File "/home/sonata/miniconda3/lib/python3.8/site-packages/setigen/voltage/backend.py", line 173, in _make_header
    with open(path, 'r') as t:
FileNotFoundError: [Errno 2] No such file or directory: '/home/sonata/miniconda3/lib/python3.8/site-packages/setigen/voltage/header_template.txt'
```