### PR TITLE
Feature/20260421 bbrzycki accelerate voltage experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,17 @@ and [`SCIENCE.md`](SCIENCE.md).
 currently imports `pkg_resources` at runtime. Normal installs pick this up
 automatically.
 
-The `setigen.voltage` module specifically can be GPU accelerated, via CuPy (https://docs.cupy.dev/en/stable/install.html). CuPy is not strictly required to use the voltage module, but it reduces compute time significantly. If CuPy is installed, enable `setigen` GPU usage either by setting the `SETIGEN_ENABLE_GPU` environmental variable to 1 or doing so in Python:
+The `setigen.voltage` module specifically can be GPU accelerated, via CuPy (https://docs.cupy.dev/en/stable/install.html). CuPy is not strictly required to use the voltage module, but it reduces compute time significantly. If CuPy is installed, enable `setigen` GPU usage before constructing voltage objects:
 
 ```
 import os
-os.environ['SETIGEN_ENABLE_GPU'] = '1'
 os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+
+import setigen as stg
+stg.voltage.set_backend('cupy')
 ```
+
+The legacy `SETIGEN_ENABLE_GPU=1` environment variable is still supported for existing scripts. Use `stg.voltage.set_backend('numpy')` to force CPU execution.
 
 While it isn’t used directly by `setigen`, you may also find it helpful to install [`cusignal`](https://github.com/rapidsai/cusignal) for access to CUDA-enabled versions of `scipy` functions when writing custom voltage signal source functions.
 

--- a/benchmarks/voltage_selected_bins.py
+++ b/benchmarks/voltage_selected_bins.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from collections.abc import Iterable
+
+import numpy as np
+
+import setigen as stg
+
+
+def _parse_counts(raw_counts: str) -> list[int]:
+    """Parse a comma-separated list of selected coarse-channel counts."""
+    return [int(item.strip()) for item in raw_counts.split(",") if item.strip()]
+
+
+def _time_call(repeats: int, func: object) -> float:
+    """Return the best runtime across repeated calls."""
+    timings = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        func()
+        timings.append(time.perf_counter() - start)
+    return min(timings)
+
+
+def run_benchmark(
+    *,
+    num_taps: int,
+    num_branches: int,
+    windows: int,
+    counts: Iterable[int],
+    repeats: int,
+    seed: int,
+) -> None:
+    """Benchmark full-FFT slicing against selected-bin PFB channelization."""
+    rng = np.random.default_rng(seed)
+    samples = rng.standard_normal(num_taps * num_branches * windows)
+
+    print(
+        "backend={backend} taps={taps} branches={branches} windows={windows} repeats={repeats}".format(
+            backend="cupy" if os.getenv("SETIGEN_ENABLE_GPU") == "1" else "numpy",
+            taps=num_taps,
+            branches=num_branches,
+            windows=windows,
+            repeats=repeats,
+        )
+    )
+    print("channels,full_seconds,selected_seconds,speedup")
+
+    for count in counts:
+        full_filterbank = stg.voltage.PolyphaseFilterbank(
+            num_taps=num_taps,
+            num_branches=num_branches,
+        )
+        selected_filterbank = stg.voltage.PolyphaseFilterbank(
+            num_taps=num_taps,
+            num_branches=num_branches,
+        )
+
+        full_seconds = _time_call(
+            repeats,
+            lambda: full_filterbank.channelize(
+                samples,
+                cache=False,
+                start_chan=0,
+                num_chans=count,
+                method="full",
+            ),
+        )
+        selected_seconds = _time_call(
+            repeats,
+            lambda: selected_filterbank.channelize(
+                samples,
+                cache=False,
+                start_chan=0,
+                num_chans=count,
+                method="selected",
+            ),
+        )
+        speedup = full_seconds / selected_seconds if selected_seconds else float("inf")
+        print(f"{count},{full_seconds:.8f},{selected_seconds:.8f},{speedup:.3f}")
+
+
+def main() -> None:
+    """Run the selected-bin voltage benchmark."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--num-taps", type=int, default=8)
+    parser.add_argument("--num-branches", type=int, default=1024)
+    parser.add_argument("--windows", type=int, default=16)
+    parser.add_argument("--counts", default="1,2,4,8,16,64")
+    parser.add_argument("--repeats", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    run_benchmark(
+        num_taps=args.num_taps,
+        num_branches=args.num_branches,
+        windows=args.windows,
+        counts=_parse_counts(args.counts),
+        repeats=args.repeats,
+        seed=args.seed,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/voltage_selected_bins.py
+++ b/benchmarks/voltage_selected_bins.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import time
 from collections.abc import Iterable
 
@@ -40,7 +39,7 @@ def run_benchmark(
 
     print(
         "backend={backend} taps={taps} branches={branches} windows={windows} repeats={repeats}".format(
-            backend="cupy" if os.getenv("SETIGEN_ENABLE_GPU") == "1" else "numpy",
+            backend=stg.voltage.get_backend(),
             taps=num_taps,
             branches=num_branches,
             windows=windows,
@@ -92,8 +91,10 @@ def main() -> None:
     parser.add_argument("--counts", default="1,2,4,8,16,64")
     parser.add_argument("--repeats", type=int, default=5)
     parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--backend", choices=("auto", "numpy", "cupy"), default="auto")
     args = parser.parse_args()
 
+    stg.voltage.set_backend(args.backend)
     run_benchmark(
         num_taps=args.num_taps,
         num_branches=args.num_branches,

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -63,7 +63,11 @@ To use GPU with setigen.voltage
 ``setigen.voltage``'s GPU acceleration is powered by CuPy 
 (https://docs.cupy.dev/en/stable/install.html). Installation is not required 
 to use vanilla |setigen| or the voltage module, but it is highly recommended 
-to accelerate voltage computations. While it isn't used directly by |setigen|, 
+to accelerate voltage computations. Enable it with
+``stg.voltage.set_backend('cupy')`` before constructing voltage objects. Use
+``stg.voltage.set_backend('numpy')`` to force CPU execution. The legacy
+``SETIGEN_ENABLE_GPU=1`` environment variable is still supported for existing
+scripts. While it isn't used directly by |setigen|,
 you may also find it helpful to install ``cusignal`` 
 (https://github.com/rapidsai/cusignal) for access to CUDA-enabled versions of 
 ``scipy`` functions when writing custom voltage signal source functions.

--- a/docs/source/setigen.voltage.rst
+++ b/docs/source/setigen.voltage.rst
@@ -62,3 +62,18 @@ setigen.voltage.waterfall module
     :undoc-members:
     :show-inheritance:
 
+setigen.voltage.reduction module
+--------------------------------
+
+.. automodule:: setigen.voltage.reduction
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+setigen.voltage.spectrogram module
+----------------------------------
+
+.. automodule:: setigen.voltage.spectrogram
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/voltages.rst
+++ b/docs/source/voltages.rst
@@ -204,17 +204,15 @@ to install CuPy, which performs the equivalent NumPy array operations on the
 GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to 
 run raw voltage generation, but will highly accelerate the pipeline. 
 
-Once you have CuPy installed, to enable GPU acceleration, you must set 
-``SETIGEN_ENABLE_GPU`` to '1' in the shell or in Python via 
-``os.environ``. It can also be useful to set ``CUDA_VISIBLE_DEVICES`` 
-to specify which GPUs to use. The following enables GPU usage and specifies to 
-use the GPU indexed as 0.
+Once you have CuPy installed, enable GPU acceleration before constructing
+voltage objects. It can also be useful to set ``CUDA_VISIBLE_DEVICES`` to
+specify which GPUs to use. The following enables GPU usage and specifies to use
+the GPU indexed as 0.
 
 In Bash:
 
 .. code-block:: bash
 
-    export SETIGEN_ENABLE_GPU=1
     export CUDA_VISIBLE_DEVICES=0
     
 In Python:
@@ -222,8 +220,14 @@ In Python:
 .. code-block:: python
 
     import os
-    os.environ['SETIGEN_ENABLE_GPU'] = '1'
     os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+
+    import setigen as stg
+    stg.voltage.set_backend('cupy')
+
+The legacy ``SETIGEN_ENABLE_GPU=1`` environment variable is still supported for
+existing scripts. Use ``stg.voltage.set_backend('numpy')`` to force CPU
+execution.
     
 Details behind classes
 ----------------------

--- a/docs/source/voltages.rst
+++ b/docs/source/voltages.rst
@@ -338,6 +338,15 @@ are:
 - ``num_taps`` controls the spectral profile of each individual coarse channel. The larger this is, the closer the spectral response gets to ideal.
 - ``num_branches`` controls the number of coarse channels. After the real FFT, we obtain ``num_branches / 2`` total coarse channels spanning the Nyquist range.
 
+The PFB frontend uses the original row-loop implementation by default for both
+NumPy and CuPy backends. A tap-vectorized frontend is available for local
+experiments by setting ``filterbank.frontend_method = 'vectorized'``, but it is
+not enabled automatically because it can increase temporary memory use and is
+not guaranteed to be faster for every backend or block size. This frontend
+choice is separate from ``coarse_method='auto'`` in direct spectrogram
+generation, which controls whether the coarse-channel FFT computes all coarse
+DFT bins or only selected output bins.
+
 Voltage backend
 ^^^^^^^^^^^^^^^
 

--- a/docs/source/voltages.rst
+++ b/docs/source/voltages.rst
@@ -139,6 +139,61 @@ acceleration, and rawspec-style polarization semantics for ``pol_mode=1``,
 directly and are not wrapped in :class:`~setigen.frame.Frame`, which remains a
 2D total-power interface.
 
+Direct voltage spectrograms
+---------------------------
+
+When the desired product is a dynamic spectrum rather than a persistent RAW
+file, :meth:`~setigen.voltage.backend.RawVoltageBackend.to_spectrogram` can run
+the same exact voltage path and skip the intermediate RAW serialization step.
+The backend still generates voltage samples, applies the digitizer, coarse PFB,
+and complex requantizer, and then performs fine channelization and integration
+directly in Python.
+
+.. code-block:: python
+
+    spec = stg.voltage.VoltageSpectrogramSpec(
+        fftlength=1024,
+        integration_factor=4,
+        pol_mode=stg.voltage.PolarizationMode.TOTAL_POWER,
+        coarse_method='auto',
+        fine_method='auto',
+    )
+
+    result = rvb.to_spectrogram(spec,
+                                num_blocks=1,
+                                length_mode='num_blocks',
+                                verbose=False)
+    frame = result.to_frame()
+
+The ``coarse_method`` and ``fine_method`` options accept ``'auto'``,
+``'full'``, and ``'selected'``. Automatic selection is used only for exact
+methods that preserve the current channel response and FFT normalization. For
+small coarse-channel or fine-channel selections, ``'auto'`` may compute only
+the requested DFT bins; otherwise it falls back to the full FFT path.
+
+For targeted analysis, the direct spectrogram and RAW reduction APIs support
+frequency-region selection on the final fine-channel axis:
+
+.. code-block:: python
+
+    roi = stg.voltage.VoltageSpectrogramSpec(
+        fftlength=1024,
+        integration_factor=4,
+        frequency_range=(6001.0e6, 6001.5e6),
+        fine_method='selected',
+    )
+
+    frame = rvb.to_spectrogram(roi,
+                               num_blocks=1,
+                               length_mode='num_blocks',
+                               verbose=False).to_frame()
+
+The frequency range is mutually exclusive with ``start_chan`` and
+``num_chans``. Existing RAW generation remains available through
+:meth:`~setigen.voltage.backend.RawVoltageBackend.record`; direct spectrogram
+generation does not write a RAW file unless users separately call
+``record``.
+
 Using GPU acceleration
 ----------------------
 

--- a/jupyter-notebooks/voltage/00_raw_file_gen.ipynb
+++ b/jupyter-notebooks/voltage/00_raw_file_gen.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -42,7 +42,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -59,7 +58,8 @@
     "from astropy import units as u\n",
     "import blimpy as bl\n",
     "\n",
-    "import setigen as stg"
+    "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')"
    ]
   },
   {

--- a/jupyter-notebooks/voltage/01_multi_antenna_raw_file_gen.ipynb
+++ b/jupyter-notebooks/voltage/01_multi_antenna_raw_file_gen.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -58,7 +57,8 @@
     "from astropy import units as u\n",
     "import blimpy as bl\n",
     "\n",
-    "import setigen as stg"
+    "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')"
    ]
   },
   {

--- a/jupyter-notebooks/voltage/02_deconstructed_pipeline.ipynb
+++ b/jupyter-notebooks/voltage/02_deconstructed_pipeline.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -64,6 +63,7 @@
     "import blimpy as bl\n",
     "\n",
     "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')\n",
     "\n",
     "def get_numpy(v):\n",
     "    try:\n",

--- a/jupyter-notebooks/voltage/03_custom_signals.ipynb
+++ b/jupyter-notebooks/voltage/03_custom_signals.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -48,7 +47,8 @@
     "from astropy import units as u\n",
     "import blimpy as bl\n",
     "\n",
-    "import setigen as stg"
+    "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')"
    ]
   },
   {

--- a/jupyter-notebooks/voltage/04_custom_signals_estimate_noise.ipynb
+++ b/jupyter-notebooks/voltage/04_custom_signals_estimate_noise.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -58,7 +57,8 @@
     "from astropy import units as u\n",
     "import blimpy as bl\n",
     "\n",
-    "import setigen as stg"
+    "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')"
    ]
   },
   {

--- a/jupyter-notebooks/voltage/05_raw_file_gen_snr.ipynb
+++ b/jupyter-notebooks/voltage/05_raw_file_gen_snr.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -58,7 +57,8 @@
     "from astropy import units as u\n",
     "import blimpy as bl\n",
     "\n",
-    "import setigen as stg"
+    "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')"
    ]
   },
   {

--- a/jupyter-notebooks/voltage/06_starting_from_existing_raw_files.ipynb
+++ b/jupyter-notebooks/voltage/06_starting_from_existing_raw_files.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -48,7 +47,8 @@
     "from astropy import units as u\n",
     "import blimpy as bl\n",
     "\n",
-    "import setigen as stg"
+    "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')"
    ]
   },
   {

--- a/jupyter-notebooks/voltage/07_efficient_gen_by_subsampling.ipynb
+++ b/jupyter-notebooks/voltage/07_efficient_gen_by_subsampling.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, to enable GPU acceleration you must set `SETIGEN_ENABLE_GPU` to '1' in the shell or in Python via `os.environ`. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
+    "If you have access to a GPU, it is highly recommended to install CuPy, which performs the equivalent NumPy array operations on the GPU (https://docs.cupy.dev/en/stable/install.html). This is not necessary to run raw voltage generation, but will highly accelerate the pipeline. Once you have CuPy installed, enable GPU acceleration with `stg.voltage.set_backend('cupy')` before constructing voltage objects. It can also be useful to set `CUDA_VISIBLE_DEVICES` to specify which GPUs to use."
    ]
   },
   {
@@ -31,7 +31,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ['SETIGEN_ENABLE_GPU'] = '1'\n",
     "os.environ['CUDA_VISIBLE_DEVICES'] = '0'"
    ]
   },
@@ -58,7 +57,8 @@
     "from astropy import units as u\n",
     "import blimpy as bl\n",
     "\n",
-    "import setigen as stg"
+    "import setigen as stg\n",
+    "stg.voltage.set_backend('cupy')"
    ]
   },
   {

--- a/setigen/voltage/__init__.py
+++ b/setigen/voltage/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from setigen.voltage._array_backend import get_backend, set_backend
 from setigen.voltage.data_stream import (
     DataStream, BackgroundDataStream, estimate_stats
 )
@@ -30,6 +31,8 @@ from setigen.voltage.spectrogram import (
 )
 
 __all__ = [
+    "get_backend",
+    "set_backend",
     "DataStream",
     "BackgroundDataStream",
     "estimate_stats",

--- a/setigen/voltage/__init__.py
+++ b/setigen/voltage/__init__.py
@@ -24,6 +24,10 @@ from setigen.voltage.reduction import (
     reduce_raw,
     reduce_raw_to_frame,
 )
+from setigen.voltage.spectrogram import (
+    VoltageSpectrogramResult,
+    VoltageSpectrogramSpec,
+)
 
 __all__ = [
     "DataStream",
@@ -52,4 +56,6 @@ __all__ = [
     "RawReductionSpec",
     "reduce_raw",
     "reduce_raw_to_frame",
+    "VoltageSpectrogramResult",
+    "VoltageSpectrogramSpec",
 ]

--- a/setigen/voltage/_array_backend.py
+++ b/setigen/voltage/_array_backend.py
@@ -14,16 +14,40 @@ _modules: dict[str, Any] = {"numpy": np}
 
 
 def _env_backend() -> ArrayBackend:
+    """Resolve the legacy environment-selected backend.
+
+    Returns:
+        ``"cupy"`` when ``SETIGEN_ENABLE_GPU=1``; otherwise ``"numpy"``.
+    """
     return "cupy" if os.getenv("SETIGEN_ENABLE_GPU", "0") == "1" else "numpy"
 
 
 def _validate_backend(backend: str) -> ArrayBackend:
+    """Validate and normalize an array backend name.
+
+    Args:
+        backend: Backend name to validate.
+
+    Returns:
+        Validated backend name.
+
+    Raises:
+        ValueError: If the backend name is unsupported.
+    """
     if backend not in ("auto", "numpy", "cupy"):
         raise ValueError("backend must be one of 'auto', 'numpy', or 'cupy'.")
     return backend  # type: ignore[return-value]
 
 
 def _import_cupy() -> Any:
+    """Import and cache CuPy.
+
+    Returns:
+        Imported CuPy module.
+
+    Raises:
+        ImportError: If CuPy is unavailable.
+    """
     if "cupy" not in _modules:
         try:
             _modules["cupy"] = importlib.import_module("cupy")
@@ -94,12 +118,23 @@ def get_array_module(backend: str | None = None) -> Any:
 
 
 def get_backend() -> str:
-    """Return the currently active concrete backend name."""
+    """Return the currently active concrete backend name.
+
+    Returns:
+        Concrete backend name, either ``"numpy"`` or ``"cupy"``.
+    """
     return "cupy" if get_array_module().__name__ == "cupy" else "numpy"
 
 
 def asnumpy(array: Any) -> np.ndarray:
-    """Return ``array`` as a NumPy array, copying from the GPU when needed."""
+    """Return ``array`` as a NumPy array, copying from the GPU when needed.
+
+    Args:
+        array: NumPy-like or CuPy-like array.
+
+    Returns:
+        Host-side NumPy array.
+    """
     module = get_array_module()
     if module is not np and hasattr(module, "asnumpy"):
         return module.asnumpy(array)
@@ -111,9 +146,22 @@ class _ArrayModuleProxy:
 
     @property
     def __name__(self) -> str:
+        """Return the active array module name.
+
+        Returns:
+            Active module name.
+        """
         return get_array_module().__name__
 
     def __getattr__(self, name: str) -> Any:
+        """Forward attribute lookups to the active array module.
+
+        Args:
+            name: Attribute name to resolve.
+
+        Returns:
+            Attribute from the active array module.
+        """
         return getattr(get_array_module(), name)
 
     def __repr__(self) -> str:

--- a/setigen/voltage/_array_backend.py
+++ b/setigen/voltage/_array_backend.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any, Literal
+
+import numpy as np
+
+
+ArrayBackend = Literal["auto", "numpy", "cupy"]
+
+_backend: ArrayBackend = "auto"
+_modules: dict[str, Any] = {"numpy": np}
+
+
+def _env_backend() -> ArrayBackend:
+    return "cupy" if os.getenv("SETIGEN_ENABLE_GPU", "0") == "1" else "numpy"
+
+
+def _validate_backend(backend: str) -> ArrayBackend:
+    if backend not in ("auto", "numpy", "cupy"):
+        raise ValueError("backend must be one of 'auto', 'numpy', or 'cupy'.")
+    return backend  # type: ignore[return-value]
+
+
+def _import_cupy() -> Any:
+    if "cupy" not in _modules:
+        try:
+            _modules["cupy"] = importlib.import_module("cupy")
+        except ImportError as exc:
+            raise ImportError(
+                "CuPy backend requested, but CuPy is not installed. "
+                "Install the CuPy package matching your CUDA runtime, or use "
+                "stg.voltage.set_backend('numpy')."
+            ) from exc
+    return _modules["cupy"]
+
+
+def set_backend(backend: str) -> None:
+    """Set the default array backend for voltage synthesis.
+
+    Call this before constructing voltage objects so their arrays, cached
+    windows, and random generators are created with the intended backend.
+
+    Args:
+        backend: ``"numpy"``, ``"cupy"``, or ``"auto"``. ``"auto"`` follows
+            the legacy ``SETIGEN_ENABLE_GPU`` environment variable policy.
+
+    Raises:
+        ImportError: If ``backend="cupy"`` is requested but CuPy is unavailable.
+        ValueError: If the backend name is unsupported.
+    """
+    global _backend
+
+    backend = _validate_backend(backend)
+    if backend == "cupy":
+        _import_cupy()
+    _backend = backend
+
+
+def get_array_module(backend: str | None = None) -> Any:
+    """Return the active NumPy- or CuPy-compatible array module.
+
+    Args:
+        backend: Optional explicit backend. ``None`` and ``"auto"`` follow the
+            global backend setting, which defaults to the legacy environment
+            variable policy.
+
+    Returns:
+        ``numpy`` or ``cupy``.
+
+    Raises:
+        ImportError: If CuPy is explicitly requested but unavailable.
+        ValueError: If the backend name is unsupported.
+    """
+    fallback_to_numpy = False
+    if backend is None or backend == "auto":
+        backend = _backend
+        if backend == "auto":
+            backend = _env_backend()
+            fallback_to_numpy = True
+    backend = _validate_backend(backend)
+
+    if backend == "numpy":
+        return np
+    if backend == "cupy":
+        try:
+            return _import_cupy()
+        except ImportError:
+            if fallback_to_numpy:
+                return np
+            raise
+    return np
+
+
+def get_backend() -> str:
+    """Return the currently active concrete backend name."""
+    return "cupy" if get_array_module().__name__ == "cupy" else "numpy"
+
+
+def asnumpy(array: Any) -> np.ndarray:
+    """Return ``array`` as a NumPy array, copying from the GPU when needed."""
+    module = get_array_module()
+    if module is not np and hasattr(module, "asnumpy"):
+        return module.asnumpy(array)
+    return np.asarray(array)
+
+
+class _ArrayModuleProxy:
+    """Late-bound array module proxy used by voltage internals."""
+
+    @property
+    def __name__(self) -> str:
+        return get_array_module().__name__
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_array_module(), name)
+
+    def __repr__(self) -> str:
+        return repr(get_array_module())
+
+
+xp = _ArrayModuleProxy()

--- a/setigen/voltage/_backend/pipeline.py
+++ b/setigen/voltage/_backend/pipeline.py
@@ -227,6 +227,9 @@ def _channelize_voltage(
     antenna: int,
     pol: int,
     digitize: bool,
+    start_chan: int | None = None,
+    num_chans: int | None = None,
+    coarse_method: str = "auto",
 ) -> Any:
     """Digitize, PFB-channelize, and coarse-channel select one voltage stream.
 
@@ -236,18 +239,33 @@ def _channelize_voltage(
         antenna: Antenna index.
         pol: Polarization index.
         digitize: Whether to digitize before PFB channelization.
+        start_chan: Optional first coarse channel to return. Defaults to the
+            backend recording start channel.
+        num_chans: Optional number of coarse channels to return. Defaults to
+            the backend recording channel count.
+        coarse_method: Coarse-channel transform method for the PFB.
 
     Returns:
         Complex coarse-channel voltages for the selected channel slice.
     """
+    if start_chan is None:
+        start_chan = backend.start_chan
+    if num_chans is None:
+        num_chans = backend.num_chans
+
     if digitize:
         start = time.time()
         v = backend.digitizer[antenna][pol].quantize(v)
         backend.digitizer_stage_t += time.time() - start
 
     start = time.time()
-    v = backend.filterbank[antenna][pol].channelize(v, cache=True)
-    v = v[:, backend.start_chan : backend.start_chan + backend.num_chans]
+    v = backend.filterbank[antenna][pol].channelize(
+        v,
+        cache=True,
+        start_chan=start_chan,
+        num_chans=num_chans,
+        method=coarse_method,
+    )
     backend.filterbank_stage_t += time.time() - start
     return v
 

--- a/setigen/voltage/_reduction/channelize.py
+++ b/setigen/voltage/_reduction/channelize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
@@ -59,6 +60,58 @@ def _fftshifted_spectra(voltages: np.ndarray, *, fftlength: int, xp: Any) -> lis
     return spectra_by_pol
 
 
+def _selected_fftshifted_spectra(
+    voltages: np.ndarray,
+    *,
+    fftlength: int,
+    channel_indices: Sequence[int],
+    xp: Any,
+) -> list[Any] | None:
+    """Fine-channelize selected flattened frequency bins from one RAW block.
+
+    Args:
+        voltages: Decoded coarse-channel voltages with time, coarse-channel,
+            and polarization axes.
+        fftlength: Fine-channel FFT length.
+        channel_indices: Flattened fine-channel indices to return, ordered as
+            in the full coarse/fine flattened product.
+        xp: Numerical array module, either NumPy or CuPy.
+
+    Returns:
+        Per-polarization FFT-shifted spectra with shape ``(time, frequency)``,
+        or ``None`` if no complete FFT row can be formed.
+    """
+    trimmed = voltages[: (voltages.shape[0] // fftlength) * fftlength]
+    if trimmed.shape[0] == 0:
+        return None
+
+    channel_indices = np.asarray(channel_indices, dtype=int)
+    if channel_indices.size == 0:
+        return None
+    max_index = voltages.shape[1] * fftlength
+    if np.any(channel_indices < 0) or np.any(channel_indices >= max_index):
+        raise ValueError("Selected fine-channel indices are out of bounds.")
+
+    coarse_indices = channel_indices // fftlength
+    shifted_fine_indices = channel_indices % fftlength
+    fft_bins = (shifted_fine_indices + fftlength // 2) % fftlength
+    unique_coarse = np.unique(coarse_indices)
+
+    sample_idx = xp.arange(fftlength)
+    spectra_by_pol = []
+    for pol in range(trimmed.shape[2]):
+        samples = xp.asarray(trimmed[:, :, pol]).T
+        samples = samples.reshape((samples.shape[0], samples.shape[1] // fftlength, fftlength))
+        out = xp.empty((samples.shape[1], channel_indices.size), dtype=complex)
+        for coarse_chan in unique_coarse:
+            out_cols = np.where(coarse_indices == coarse_chan)[0]
+            bins = xp.asarray(fft_bins[out_cols])
+            twiddle = xp.exp(-2j * xp.pi * sample_idx[:, xp.newaxis] * bins[xp.newaxis, :] / fftlength)
+            out[:, out_cols] = samples[coarse_chan] @ twiddle / fftlength**0.5
+        spectra_by_pol.append(out)
+    return spectra_by_pol
+
+
 def _integrate_products(products: Any, *, integration_factor: int, xp: Any) -> Any:
     """Integrate fine-channelized products over consecutive time rows.
 
@@ -98,6 +151,8 @@ def _channelize_block(
     integration_factor: int,
     pol_mode: int,
     backend: str,
+    channel_indices: Sequence[int] | None = None,
+    fine_method: str = "auto",
 ) -> np.ndarray | None:
     """Reduce one decoded RAW block into total-power or polarization products.
 
@@ -107,6 +162,10 @@ def _channelize_block(
         integration_factor: Number of spectra to integrate in time.
         pol_mode: Polarization output mode.
         backend: Numerical array backend name.
+        channel_indices: Optional flattened fine-channel indices to return.
+        fine_method: Fine-channel transform method. ``"full"`` computes the
+            full FFT before slicing, ``"selected"`` computes only requested
+            DFT bins, and ``"auto"`` uses selected DFT for small requests.
 
     Returns:
         Reduced spectrogram chunk, or `None` if no complete output rows are
@@ -116,8 +175,26 @@ def _channelize_block(
         ValueError: If the requested polarization mode is unsupported or
             incompatible with the decoded input.
     """
+    if fine_method not in ("auto", "full", "selected"):
+        raise ValueError("fine_method must be one of 'auto', 'full', or 'selected'.")
+
     xp = _get_array_module(backend)
-    spectra = _fftshifted_spectra(voltages, fftlength=fftlength, xp=xp)
+    if channel_indices is not None:
+        channel_indices = np.asarray(channel_indices, dtype=int)
+        if fine_method == "auto":
+            selected_limit = min(64, max(1, fftlength // 8))
+            fine_method = "selected" if len(channel_indices) <= selected_limit else "full"
+    if channel_indices is not None and fine_method == "selected":
+        spectra = _selected_fftshifted_spectra(
+            voltages,
+            fftlength=fftlength,
+            channel_indices=channel_indices,
+            xp=xp,
+        )
+        selected_output = True
+    else:
+        spectra = _fftshifted_spectra(voltages, fftlength=fftlength, xp=xp)
+        selected_output = False
     if spectra is None:
         return None
 
@@ -126,6 +203,8 @@ def _channelize_block(
 
     if pol_mode == 1:
         total = xx if yy is None else xx + yy
+        if channel_indices is not None and not selected_output:
+            total = _flatten_channels(total)[:, channel_indices]
         integrated = _integrate_products(
             total,
             integration_factor=integration_factor,
@@ -133,7 +212,10 @@ def _channelize_block(
         )
         if integrated is None:
             return None
-        result = _flatten_channels(integrated)[:, np.newaxis, :]
+        if selected_output or channel_indices is not None:
+            result = integrated[:, np.newaxis, :]
+        else:
+            result = _flatten_channels(integrated)[:, np.newaxis, :]
     else:
         if yy is None:
             raise ValueError(
@@ -142,6 +224,12 @@ def _channelize_block(
         xy = spectra[0] * xp.conj(spectra[1])
         re_xy = xp.real(xy)
         im_xy = xp.imag(xy)
+
+        if channel_indices is not None and not selected_output:
+            xx = _flatten_channels(xx)[:, channel_indices]
+            yy = _flatten_channels(yy)[:, channel_indices]
+            re_xy = _flatten_channels(re_xy)[:, channel_indices]
+            im_xy = _flatten_channels(im_xy)[:, channel_indices]
 
         if pol_mode == 4:
             products = xp.stack((xx, yy, re_xy, im_xy), axis=1)
@@ -157,11 +245,14 @@ def _channelize_block(
         )
         if integrated is None:
             return None
-        result = integrated.reshape(
-            integrated.shape[0],
-            integrated.shape[1],
-            integrated.shape[2] * integrated.shape[3],
-        )
+        if selected_output or channel_indices is not None:
+            result = integrated
+        else:
+            result = integrated.reshape(
+                integrated.shape[0],
+                integrated.shape[1],
+                integrated.shape[2] * integrated.shape[3],
+            )
 
     if xp is not np:
         result = xp.asnumpy(result)

--- a/setigen/voltage/_reduction/channelize.py
+++ b/setigen/voltage/_reduction/channelize.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import importlib
 from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
+
+from setigen.voltage._array_backend import get_array_module
 
 
 def _get_array_module(backend: str) -> Any:
@@ -19,18 +20,10 @@ def _get_array_module(backend: str) -> Any:
     Raises:
         ValueError: If the backend value is unsupported.
     """
-    if backend == "numpy":
-        return np
-    if backend == "cupy":
-        cupy = importlib.import_module("cupy")
-        return cupy
-    if backend == "auto":
-        try:
-            cupy = importlib.import_module("cupy")
-        except ImportError:
-            return np
-        return cupy
-    raise ValueError(f"Unsupported reduction backend '{backend}'.")
+    try:
+        return get_array_module(backend)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported reduction backend '{backend}'.") from exc
 
 
 def _fftshifted_spectra(voltages: np.ndarray, *, fftlength: int, xp: Any) -> list[Any] | None:

--- a/setigen/voltage/_reduction/metadata.py
+++ b/setigen/voltage/_reduction/metadata.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import numpy as np
+
 
 @dataclass(frozen=True)
 class _ReductionMetadata:
@@ -16,6 +18,57 @@ class _ReductionMetadata:
     fch1_hz: float
     ascending: bool
     total_fchans: int
+    channel_start: int = 0
+    channel_stop: int | None = None
+
+
+def _validate_selection_args(reduction_spec: Any) -> None:
+    """Validate mutually exclusive coarse and frequency selections.
+
+    Args:
+        reduction_spec: Reduction configuration.
+
+    Raises:
+        ValueError: If mutually exclusive selections are supplied together.
+    """
+    has_coarse = reduction_spec.start_chan is not None or reduction_spec.num_chans is not None
+    has_frequency = getattr(reduction_spec, "frequency_range", None) is not None
+    if has_coarse and has_frequency:
+        raise ValueError("frequency_range is mutually exclusive with start_chan/num_chans.")
+
+
+def _frequency_channel_slice(
+    *,
+    fch1_hz: float,
+    df_hz: float,
+    total_fchans: int,
+    ascending: bool,
+    frequency_range: tuple[float, float],
+) -> tuple[int, int, float]:
+    """Resolve a frequency range to a contiguous flattened channel slice.
+
+    Args:
+        fch1_hz: Frequency of the first flattened channel in Hz.
+        df_hz: Positive channel spacing in Hz.
+        total_fchans: Total number of flattened fine channels before slicing.
+        ascending: Whether frequencies increase with channel index.
+        frequency_range: Inclusive frequency bounds in Hz.
+
+    Returns:
+        Tuple of start index, stop index, and selected first-channel frequency.
+
+    Raises:
+        ValueError: If no channels intersect the requested range.
+    """
+    f_min, f_max = sorted(float(f) for f in frequency_range)
+    sign = 1 if ascending else -1
+    freqs = fch1_hz + sign * df_hz * np.arange(total_fchans)
+    selected = np.flatnonzero((freqs >= f_min) & (freqs <= f_max))
+    if selected.size == 0:
+        raise ValueError("frequency_range does not overlap the reduced frequency axis.")
+    start = int(selected[0])
+    stop = int(selected[-1] + 1)
+    return start, stop, float(freqs[start])
 
 
 def _build_reduction_metadata(input_spec: Any, reduction_spec: Any) -> _ReductionMetadata:
@@ -31,6 +84,8 @@ def _build_reduction_metadata(input_spec: Any, reduction_spec: Any) -> _Reductio
     Raises:
         ValueError: If the requested coarse-channel slice is out of bounds.
     """
+    _validate_selection_args(reduction_spec)
+
     start_chan = 0 if reduction_spec.start_chan is None else reduction_spec.start_chan
     num_chans = (
         input_spec.num_chans - start_chan
@@ -46,6 +101,20 @@ def _build_reduction_metadata(input_spec: Any, reduction_spec: Any) -> _Reductio
     dt_s = input_spec.tbin * reduction_spec.fftlength * reduction_spec.integration_factor
     coarse_fch1 = input_spec.fch1 + start_chan * input_spec.chan_bw
     fch1_hz = coarse_fch1 - input_spec.chan_bw / 2
+    total_fchans = num_chans * reduction_spec.fftlength
+    channel_start = 0
+    channel_stop = total_fchans
+
+    frequency_range = getattr(reduction_spec, "frequency_range", None)
+    if frequency_range is not None:
+        channel_start, channel_stop, fch1_hz = _frequency_channel_slice(
+            fch1_hz=fch1_hz,
+            df_hz=df_hz,
+            total_fchans=total_fchans,
+            ascending=input_spec.ascending,
+            frequency_range=frequency_range,
+        )
+        total_fchans = channel_stop - channel_start
 
     return _ReductionMetadata(
         start_chan=start_chan,
@@ -55,5 +124,7 @@ def _build_reduction_metadata(input_spec: Any, reduction_spec: Any) -> _Reductio
         dt_s=dt_s,
         fch1_hz=fch1_hz,
         ascending=input_spec.ascending,
-        total_fchans=num_chans * reduction_spec.fftlength,
+        total_fchans=total_fchans,
+        channel_start=channel_start,
+        channel_stop=channel_stop,
     )

--- a/setigen/voltage/antenna.py
+++ b/setigen/voltage/antenna.py
@@ -1,20 +1,11 @@
 from __future__ import annotations
 
-import os
 import numpy as np
-
-GPU_FLAG = os.getenv('SETIGEN_ENABLE_GPU', '0')
-if GPU_FLAG == '1':
-    try:
-        import cupy as xp
-    except ImportError:
-        import numpy as xp
-else:
-    import numpy as xp
 
 from astropy import units as u
 from typing import Any
 
+from ._array_backend import xp
 from ._antenna.array_ops import (
     _apply_background_to_antenna,
     _collect_array_samples,

--- a/setigen/voltage/backend.py
+++ b/setigen/voltage/backend.py
@@ -420,6 +420,52 @@ class RawVoltageBackend(object):
                       record_config=record_config,
                       header_dict=header_dict,
                       xp=xp)
+
+    def to_spectrogram(
+        self,
+        spec: Any,
+        obs_length: float | None = None,
+        num_blocks: int | None = None,
+        length_mode: str = "obs_length",
+        digitize: bool = True,
+        requantize: bool = True,
+        verbose: bool = True,
+    ) -> Any:
+        """Generate a reduced spectrogram directly from this backend.
+
+        This follows the same voltage path as :meth:`record` through sample
+        generation, digitization, coarse PFB channelization, and requantization,
+        then reduces directly to a spectrogram without packing, writing,
+        reading, or decoding an intermediate RAW file.
+
+        Args:
+            spec: :class:`setigen.voltage.VoltageSpectrogramSpec` instance.
+            obs_length: Observation length in seconds when using
+                ``length_mode="obs_length"``.
+            num_blocks: Number of backend blocks when using
+                ``length_mode="num_blocks"``.
+            length_mode: Strategy for interpreting the supplied observation
+                length.
+            digitize: Whether to quantize input voltages before the PFB.
+            requantize: Whether to quantize complex post-PFB voltages.
+            verbose: Whether to emit progress output.
+
+        Returns:
+            :class:`setigen.voltage.VoltageSpectrogramResult`.
+        """
+        from setigen.voltage.spectrogram import generate_voltage_spectrogram
+
+        return generate_voltage_spectrogram(
+            self,
+            spec,
+            obs_length=obs_length,
+            num_blocks=num_blocks,
+            length_mode=length_mode,
+            digitize=digitize,
+            requantize=requantize,
+            verbose=verbose,
+            xp=xp,
+        )
                     
              
 def get_block_size(num_antennas: int = 1,

--- a/setigen/voltage/backend.py
+++ b/setigen/voltage/backend.py
@@ -1,13 +1,3 @@
-import os
-
-GPU_FLAG = os.getenv('SETIGEN_ENABLE_GPU', '0')
-if GPU_FLAG == '1':
-    try:
-        import cupy as xp
-    except ImportError:
-        import numpy as xp
-else:
-    import numpy as xp
 import numpy as np
 
 from tqdm import tqdm
@@ -18,6 +8,7 @@ from setigen.voltage import raw_utils
 from setigen.voltage import polyphase_filterbank
 from setigen.voltage import quantization
 from setigen.voltage import antenna as v_antenna
+from setigen.voltage._array_backend import xp
 from setigen.voltage._backend.headers import (
     _read_next_block,
 )

--- a/setigen/voltage/cli.py
+++ b/setigen/voltage/cli.py
@@ -54,11 +54,21 @@ def _validate_output_path(ctx: click.Context,
               type=click.IntRange(min=1),
               default=None,
               help="Number of coarse channels to reduce.")
+@click.option("--frequency-range",
+              nargs=2,
+              type=float,
+              default=None,
+              help="Inclusive final-frequency range to reduce, in Hz.")
 @click.option("--backend",
               type=click.Choice(["auto", "numpy", "cupy"]),
               default="auto",
               show_default=True,
               help="Array backend for fine channelization.")
+@click.option("--fine-method",
+              type=click.Choice(["auto", "full", "selected"]),
+              default="auto",
+              show_default=True,
+              help="Fine-channel FFT method.")
 @click.option("--overwrite",
               is_flag=True,
               help="Allow overwriting the output file if it already exists.")
@@ -74,7 +84,9 @@ def main(input_path: Path,
          output_format: str,
          start_chan: int | None,
          num_chans: int | None,
+         frequency_range: tuple[float, float] | None,
          backend: str,
+         fine_method: str,
          overwrite: bool,
          tmp_dir: Path | None) -> None:
     """
@@ -92,7 +104,9 @@ def main(input_path: Path,
         output_format: Output file format.
         start_chan: First coarse channel to reduce.
         num_chans: Number of coarse channels to reduce.
+        frequency_range: Inclusive final-frequency range to reduce, in Hz.
         backend: Numerical array backend name.
+        fine_method: Fine-channel FFT method.
         overwrite: Whether an existing output file may be replaced.
         tmp_dir: Optional directory for staged writes.
     """
@@ -103,7 +117,9 @@ def main(input_path: Path,
         output_format=output_format,
         start_chan=start_chan,
         num_chans=num_chans,
+        frequency_range=frequency_range,
         backend=backend,
+        fine_method=fine_method,
     )
     final_path = reduce_raw(input_path,
                             output_path,

--- a/setigen/voltage/data_stream.py
+++ b/setigen/voltage/data_stream.py
@@ -1,20 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-import os
-
-GPU_FLAG = os.getenv('SETIGEN_ENABLE_GPU', '0')
-if GPU_FLAG == '1':
-    try:
-        import cupy as xp
-    except ImportError:
-        import numpy as xp
-else:
-    import numpy as xp
 
 from astropy import units as u
 from setigen import unit_utils
 from setigen._typing import SeedLike
+from ._array_backend import xp
 
 
 class DataStream(object):

--- a/setigen/voltage/polyphase_filterbank.py
+++ b/setigen/voltage/polyphase_filterbank.py
@@ -31,6 +31,8 @@ class PolyphaseFilterbank(object):
         self.num_taps = num_taps
         self.num_branches = num_branches
         self.window_fn = window_fn
+        self.frontend_method = "reference"
+        self.max_frontend_working_set_bytes = 512 * 1024**2
         
         self.cache = None
         
@@ -142,7 +144,14 @@ class PolyphaseFilterbank(object):
                 x = xp.concatenate([self.cache, x])
             self.cache = x[-self.num_taps*self.num_branches:]
         
-        x = pfb_frontend(x, self.window, self.num_taps, self.num_branches)
+        x = pfb_frontend(
+            x,
+            self.window,
+            self.num_taps,
+            self.num_branches,
+            method=self.frontend_method,
+            max_working_set_bytes=self.max_frontend_working_set_bytes,
+        )
 
         if method == "auto":
             selected_limit = min(8, max(1, self.num_branches // 64))
@@ -197,7 +206,9 @@ def pfb_frontend_reference(x: xp.ndarray,
 def pfb_frontend(x: xp.ndarray,
                  pfb_window: xp.ndarray,
                  num_taps: int,
-                 num_branches: int) -> xp.ndarray:
+                 num_branches: int,
+                 method: Literal["auto", "reference", "vectorized"] = "auto",
+                 max_working_set_bytes: int | None = 512 * 1024**2) -> xp.ndarray:
     """Apply the vectorized polyphase frontend windowing operation.
 
     Args:
@@ -205,16 +216,33 @@ def pfb_frontend(x: xp.ndarray,
         pfb_window: PFB window coefficients.
         num_taps: Number of PFB taps.
         num_branches: Number of PFB branches.
+        method: Frontend implementation method. ``"reference"`` uses the
+            original row loop, ``"vectorized"`` loops over taps, and
+            ``"auto"`` uses the conservative reference loop. Users can request
+            ``"vectorized"`` explicitly for workloads where it is faster.
+        max_working_set_bytes: Optional memory budget for the auto selector.
 
     Returns:
         Voltage array after PFB weighting.
+
+    Raises:
+        ValueError: If the frontend method is unsupported.
     """
+    if method not in ("auto", "reference", "vectorized"):
+        raise ValueError("method must be one of 'auto', 'reference', or 'vectorized'.")
+
     W = int(len(x) / num_taps / num_branches)
+    output_rows = (W - 1) * num_taps
+    if method == "auto":
+        # Keep auto conservative: the reference loop has the lowest peak
+        # temporary memory and no backend-dependent performance assumptions.
+        method = "reference"
+    if method == "reference":
+        return pfb_frontend_reference(x, pfb_window, num_taps, num_branches)
 
     x_p = x[:W*num_taps*num_branches].reshape((W * num_taps, num_branches))
     h_p = pfb_window.reshape((num_taps, num_branches))
 
-    output_rows = (W - 1) * num_taps
     x_summed = xp.zeros((output_rows, num_branches))
     for tap in range(num_taps):
         x_summed += x_p[tap:tap + output_rows, :] * h_p[tap, :]

--- a/setigen/voltage/polyphase_filterbank.py
+++ b/setigen/voltage/polyphase_filterbank.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import Literal
 
 GPU_FLAG = os.getenv('SETIGEN_ENABLE_GPU', '0')
 if GPU_FLAG == '1':
@@ -100,16 +101,41 @@ class PolyphaseFilterbank(object):
         return xp.tile(xp.concatenate([response[::-1], response]), 
                        num_chans)
 
-    def channelize(self, x: xp.ndarray, cache: bool = True) -> xp.ndarray:
+    def channelize(self,
+                   x: xp.ndarray,
+                   cache: bool = True,
+                   start_chan: int = 0,
+                   num_chans: int | None = None,
+                   method: Literal["auto", "full", "selected"] = "auto") -> xp.ndarray:
         """Channelize input voltages with the PFB and a normalized FFT.
 
         Args:
             x: Input voltage array.
             cache: Whether to retain overlap samples between calls.
+            start_chan: First coarse channel to return.
+            num_chans: Number of coarse channels to return. Defaults to all
+                positive-frequency channels from ``start_chan`` onward.
+            method: Coarse-channel transform method. ``"full"`` computes the
+                full FFT then slices, ``"selected"`` computes only requested
+                DFT bins, and ``"auto"`` selects the exact cheaper path for
+                small channel selections.
 
         Returns:
             Post-FFT complex voltages.
+
+        Raises:
+            ValueError: If the selected channel range or method is invalid.
         """
+        if method not in ("auto", "full", "selected"):
+            raise ValueError("method must be one of 'auto', 'full', or 'selected'.")
+        if start_chan < 0:
+            raise ValueError("start_chan must be non-negative.")
+        max_chans = self.num_branches // 2
+        if num_chans is None:
+            num_chans = max_chans - start_chan
+        if num_chans <= 0 or start_chan + num_chans > max_chans:
+            raise ValueError("Selected coarse channel range is out of bounds.")
+
         if cache:
             # Cache last section of data, which is excluded in PFB step
             if self.cache is not None:
@@ -117,16 +143,29 @@ class PolyphaseFilterbank(object):
             self.cache = x[-self.num_taps*self.num_branches:]
         
         x = pfb_frontend(x, self.window, self.num_taps, self.num_branches)
-        X_pfb = xp.fft.fft(x, 
+
+        if method == "auto":
+            selected_limit = min(8, max(1, self.num_branches // 64))
+            method = "selected" if num_chans <= selected_limit else "full"
+
+        if method == "selected":
+            bins = xp.arange(start_chan, start_chan + num_chans)
+            sample_idx = xp.arange(self.num_branches)
+            twiddle = xp.exp(
+                -2j * xp.pi * sample_idx[:, xp.newaxis] * bins[xp.newaxis, :] / self.num_branches
+            )
+            return (x @ twiddle) / self.num_branches**0.5
+
+        X_pfb = xp.fft.fft(x,
                            self.num_branches,
                            axis=1)[:, 0:self.num_branches//2] / self.num_branches**0.5
-        return X_pfb
+        return X_pfb[:, start_chan:start_chan + num_chans]
     
     
-def pfb_frontend(x: xp.ndarray,
-                 pfb_window: xp.ndarray,
-                 num_taps: int,
-                 num_branches: int) -> xp.ndarray:
+def pfb_frontend_reference(x: xp.ndarray,
+                           pfb_window: xp.ndarray,
+                           num_taps: int,
+                           num_branches: int) -> xp.ndarray:
     """Apply the polyphase frontend windowing operation.
 
     Args:
@@ -152,6 +191,33 @@ def pfb_frontend(x: xp.ndarray,
     for t in range(0, (W - 1) * num_taps):
         x_weighted = x_p[t:t+num_taps, :] * h_p
         x_summed[t, :] = xp.sum(x_weighted, axis=0)
+    return x_summed
+
+
+def pfb_frontend(x: xp.ndarray,
+                 pfb_window: xp.ndarray,
+                 num_taps: int,
+                 num_branches: int) -> xp.ndarray:
+    """Apply the vectorized polyphase frontend windowing operation.
+
+    Args:
+        x: Input voltage array.
+        pfb_window: PFB window coefficients.
+        num_taps: Number of PFB taps.
+        num_branches: Number of PFB branches.
+
+    Returns:
+        Voltage array after PFB weighting.
+    """
+    W = int(len(x) / num_taps / num_branches)
+
+    x_p = x[:W*num_taps*num_branches].reshape((W * num_taps, num_branches))
+    h_p = pfb_window.reshape((num_taps, num_branches))
+
+    output_rows = (W - 1) * num_taps
+    x_summed = xp.zeros((output_rows, num_branches))
+    for tap in range(num_taps):
+        x_summed += x_p[tap:tap + output_rows, :] * h_p[tap, :]
     return x_summed
 
 

--- a/setigen/voltage/polyphase_filterbank.py
+++ b/setigen/voltage/polyphase_filterbank.py
@@ -1,20 +1,11 @@
 from __future__ import annotations
 
-import os
 from typing import Literal
 
-GPU_FLAG = os.getenv('SETIGEN_ENABLE_GPU', '0')
-if GPU_FLAG == '1':
-    try:
-        import cupy as xp
-    except ImportError:
-        import numpy as xp
-else:
-    import numpy as xp
-    
 import scipy.signal
 
 from setigen._typing import SeedLike
+from ._array_backend import xp
 
 
 class PolyphaseFilterbank(object):

--- a/setigen/voltage/quantization.py
+++ b/setigen/voltage/quantization.py
@@ -1,18 +1,8 @@
 from __future__ import annotations
 
-import os
-
-GPU_FLAG = os.getenv('SETIGEN_ENABLE_GPU', '0')
-if GPU_FLAG == '1':
-    try:
-        import cupy as xp
-    except ImportError:
-        import numpy as xp
-else:
-    import numpy as xp
-    
 import numpy as np
 
+from ._array_backend import xp
 from . import data_stream
 
 

--- a/setigen/voltage/reduction.py
+++ b/setigen/voltage/reduction.py
@@ -38,7 +38,11 @@ class RawReductionSpec:
     output_format: Literal["fil", "h5"]
     start_chan: int | None = None
     num_chans: int | None = None
+    frequency_range: tuple[float, float] | None = None
     backend: Literal["auto", "numpy", "cupy"] = "auto"
+    accuracy: Literal["exact", "approx_zoom"] = "exact"
+    coarse_method: Literal["auto", "full", "selected"] = "auto"
+    fine_method: Literal["auto", "full", "selected"] = "auto"
 
     def __post_init__(self) -> None:
         """Validate reducer configuration.
@@ -56,10 +60,23 @@ class RawReductionSpec:
             raise ValueError(f"Unsupported output format '{self.output_format}'.")
         if self.backend not in ("auto", "numpy", "cupy"):
             raise ValueError(f"Unsupported reduction backend '{self.backend}'.")
+        if self.accuracy not in ("exact", "approx_zoom"):
+            raise ValueError(f"Unsupported accuracy mode '{self.accuracy}'.")
+        if self.accuracy != "exact":
+            raise ValueError("RAW reduction currently supports only accuracy='exact'.")
+        if self.coarse_method not in ("auto", "full", "selected"):
+            raise ValueError(f"Unsupported coarse method '{self.coarse_method}'.")
+        if self.fine_method not in ("auto", "full", "selected"):
+            raise ValueError(f"Unsupported fine method '{self.fine_method}'.")
         if self.start_chan is not None and self.start_chan < 0:
             raise ValueError("start_chan must be non-negative.")
         if self.num_chans is not None and self.num_chans <= 0:
             raise ValueError("num_chans must be positive.")
+        if self.frequency_range is not None:
+            if self.start_chan is not None or self.num_chans is not None:
+                raise ValueError("frequency_range is mutually exclusive with start_chan/num_chans.")
+            if len(self.frequency_range) != 2:
+                raise ValueError("frequency_range must contain exactly two frequency bounds.")
 
 
 def _reduce_chunks(
@@ -83,6 +100,9 @@ def _reduce_chunks(
     metadata = _build_reduction_metadata(input_spec, spec)
 
     for data_chunk in _iter_raw_data_blocks(input_spec, max_blocks=max_blocks):
+        channel_indices = None
+        if metadata.channel_start != 0 or metadata.channel_stop != metadata.num_chans * spec.fftlength:
+            channel_indices = np.arange(metadata.channel_start, metadata.channel_stop)
         voltages = _decode_raw_block(
             data_chunk,
             num_bits=input_spec.num_bits,
@@ -97,6 +117,8 @@ def _reduce_chunks(
             integration_factor=spec.integration_factor,
             pol_mode=spec.pol_mode,
             backend=spec.backend,
+            channel_indices=channel_indices,
+            fine_method=spec.fine_method,
         )
         if reduced is not None and reduced.shape[0] > 0:
             yield reduced, input_spec, metadata

--- a/setigen/voltage/spectrogram.py
+++ b/setigen/voltage/spectrogram.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Literal
+
+import numpy as np
+from astropy import units as u
+
+from ..frame import Frame
+from ._backend.headers import _read_next_block
+from ._backend.orchestration import _get_blocks_to_write, _get_num_output_files, _reset_recording_state
+from ._backend.pipeline import (
+    _channelize_voltage,
+    _get_num_samples_for_subblock,
+    _get_subblock_time_range,
+    _get_time_indices,
+    _get_windows_for_subblock,
+    _plan_subblocks,
+    _requantize_voltage,
+)
+from ._backend.recording import _RecordConfig, _resolve_num_blocks
+from ._reduction.channelize import _channelize_block
+from ._reduction.metadata import _ReductionMetadata, _build_reduction_metadata
+from ._reduction.writers import _build_filterbank_header, _create_writer
+from .reduction import PolarizationMode
+
+
+@dataclass(frozen=True)
+class VoltageSpectrogramSpec:
+    """Configuration for direct voltage-backend spectrogram generation.
+
+    Args:
+        fftlength: Fine-channel FFT length.
+        integration_factor: Number of fine spectra to integrate in time.
+        pol_mode: Polarization output mode.
+        start_chan: First coarse channel relative to the backend recorded span.
+        num_chans: Number of coarse channels to reduce.
+        frequency_range: Optional inclusive final-frequency bounds in Hz.
+        backend: Array backend for fine channelization.
+        accuracy: Accuracy policy. Only ``"exact"`` is implemented.
+        coarse_method: Coarse PFB transform method.
+        fine_method: Fine FFT transform method.
+    """
+
+    fftlength: int
+    integration_factor: int
+    pol_mode: int = PolarizationMode.TOTAL_POWER
+    start_chan: int | None = None
+    num_chans: int | None = None
+    frequency_range: tuple[float, float] | None = None
+    backend: Literal["auto", "numpy", "cupy"] = "auto"
+    accuracy: Literal["exact", "approx_zoom"] = "exact"
+    coarse_method: Literal["auto", "full", "selected"] = "auto"
+    fine_method: Literal["auto", "full", "selected"] = "auto"
+
+    def __post_init__(self) -> None:
+        """Validate spectrogram generation settings."""
+        if self.fftlength <= 0:
+            raise ValueError("fftlength must be positive.")
+        if self.integration_factor <= 0:
+            raise ValueError("integration_factor must be positive.")
+        if self.pol_mode not in tuple(mode.value for mode in PolarizationMode):
+            raise ValueError(f"Unsupported polarization mode '{self.pol_mode}'.")
+        if self.backend not in ("auto", "numpy", "cupy"):
+            raise ValueError(f"Unsupported backend '{self.backend}'.")
+        if self.accuracy not in ("exact", "approx_zoom"):
+            raise ValueError(f"Unsupported accuracy mode '{self.accuracy}'.")
+        if self.accuracy != "exact":
+            raise ValueError("Direct voltage spectrograms currently support only accuracy='exact'.")
+        if self.coarse_method not in ("auto", "full", "selected"):
+            raise ValueError(f"Unsupported coarse method '{self.coarse_method}'.")
+        if self.fine_method not in ("auto", "full", "selected"):
+            raise ValueError(f"Unsupported fine method '{self.fine_method}'.")
+        if self.start_chan is not None and self.start_chan < 0:
+            raise ValueError("start_chan must be non-negative.")
+        if self.num_chans is not None and self.num_chans <= 0:
+            raise ValueError("num_chans must be positive.")
+        if self.frequency_range is not None:
+            if self.start_chan is not None or self.num_chans is not None:
+                raise ValueError("frequency_range is mutually exclusive with start_chan/num_chans.")
+            if len(self.frequency_range) != 2:
+                raise ValueError("frequency_range must contain exactly two frequency bounds.")
+
+
+@dataclass(frozen=True)
+class VoltageSpectrogramResult:
+    """Spectrogram data and metadata produced by a voltage backend.
+
+    Args:
+        data: Spectrogram array with shape ``(time, nifs, frequency)``.
+        metadata: Derived frequency/time metadata.
+        spec: Generation specification.
+        input_spec: Minimal input descriptor used for file headers.
+    """
+
+    data: np.ndarray
+    metadata: _ReductionMetadata
+    spec: VoltageSpectrogramSpec
+    input_spec: Any
+
+    def to_frame(self) -> Frame:
+        """Return this total-power product as a :class:`setigen.Frame`.
+
+        Returns:
+            Total-power spectrogram as a :class:`setigen.Frame`.
+
+        Raises:
+            ValueError: If the result is not a total-power/Stokes-I product.
+        """
+        if self.spec.pol_mode != PolarizationMode.TOTAL_POWER:
+            raise ValueError("to_frame only supports total-power / Stokes-I spectrograms.")
+        return Frame.from_data(
+            df=self.metadata.df_hz * u.Hz,
+            dt=self.metadata.dt_s * u.s,
+            fch1=self.metadata.fch1_hz * u.Hz,
+            ascending=self.metadata.ascending,
+            data=self.data[:, 0, :],
+            metadata={
+                "pol_mode": int(self.spec.pol_mode),
+                "fftlength": self.spec.fftlength,
+                "integration_factor": self.spec.integration_factor,
+                "source": "voltage_backend",
+            },
+        )
+
+    def write(
+        self,
+        output_path: str | Path,
+        *,
+        output_format: Literal["fil", "h5"] | None = None,
+        overwrite: bool = False,
+        tmp_dir: str | Path | None = None,
+    ) -> Path:
+        """Write the spectrogram as a filterbank product.
+
+        Args:
+            output_path: Destination path.
+            output_format: Output format. If omitted, inferred from suffix.
+            overwrite: Whether an existing output file may be replaced.
+            tmp_dir: Optional staging directory.
+
+        Returns:
+            Final output path.
+        """
+        output_path = Path(output_path)
+        if output_format is None:
+            suffix = output_path.suffix.lower()
+            if suffix == ".fil":
+                output_format = "fil"
+            elif suffix == ".h5":
+                output_format = "h5"
+            else:
+                raise ValueError("output_format must be supplied when suffix is not .fil or .h5.")
+
+        header = _build_filterbank_header(
+            self.input_spec,
+            self.metadata,
+            pol_mode=self.spec.pol_mode,
+        )
+        with _create_writer(
+            output_path,
+            output_format=output_format,
+            overwrite=overwrite,
+            tmp_dir=tmp_dir,
+            header=header,
+            total_fchans=self.metadata.total_fchans,
+            nifs=self.metadata.nifs,
+        ) as writer:
+            writer.append(self.data)
+        return output_path
+
+
+def _make_direct_input_spec(backend: Any) -> Any:
+    """Build a minimal RAW-like input descriptor for direct products.
+
+    Args:
+        backend: Voltage backend providing observation geometry.
+
+    Returns:
+        Namespace containing the fields needed by reduction metadata and
+        filterbank header builders.
+    """
+    return SimpleNamespace(
+        num_chans=backend.num_chans,
+        num_pols=backend.num_pols,
+        num_bits=backend.num_bits,
+        chan_bw=backend.chan_bw,
+        tbin=backend.tbin,
+        fch1=backend.fch1 + backend.start_chan * backend.chan_bw,
+        ascending=backend.ascending,
+        source_name="SYNTHETIC",
+        rawdatafile="",
+        tstart_mjd=0,
+        stem="voltage_backend",
+    )
+
+
+def _collect_coarse_voltage_block(
+    backend: Any,
+    *,
+    metadata: _ReductionMetadata,
+    spec: VoltageSpectrogramSpec,
+    digitize: bool,
+    requantize: bool,
+    verbose: bool,
+    xp: Any,
+) -> np.ndarray:
+    """Collect one time-contiguous coarse-voltage block without RAW packing.
+
+    Args:
+        backend: Voltage backend to sample and channelize.
+        metadata: Derived spectrogram metadata.
+        spec: Spectrogram generation specification.
+        digitize: Whether to quantize input voltages before coarse PFB.
+        requantize: Whether to quantize complex post-PFB voltages.
+        verbose: Whether progress output is enabled.
+        xp: Numerical array module used by the backend.
+
+    Returns:
+        Complex coarse-voltage block with time, coarse-channel, and
+        polarization axes.
+    """
+    original_obsnchan = backend.num_chans * backend.num_antennas
+    selected_num_chans = metadata.num_chans
+    selected_obsnchan = selected_num_chans * backend.num_antennas
+    plan = _plan_subblocks(backend, obsnchan=original_obsnchan)
+    backend.num_subblocks = plan.num_subblocks
+    block_voltages = np.empty(
+        (plan.total_time_samples, selected_obsnchan, backend.num_pols),
+        dtype=np.complex64,
+    )
+
+    if backend.input_file_stem is not None:
+        if not requantize:
+            raise ValueError("Must set 'requantize=True' when using input RAW data.")
+        input_voltages = _read_next_block(backend)
+    else:
+        input_voltages = None
+
+    absolute_start_chan = backend.start_chan + metadata.start_chan
+    relative_start_chan = metadata.start_chan
+    row_offset = 0
+
+    for subblock in range(plan.num_subblocks):
+        windows = _get_windows_for_subblock(plan, backend, subblock)
+        num_samples = _get_num_samples_for_subblock(backend, windows=windows)
+        antennas_v = backend.antenna_source.get_samples(num_samples)
+
+        subblock_t_range = _get_subblock_time_range(
+            plan,
+            backend,
+            subblock=subblock,
+            windows=windows,
+        )
+        rows_written = None
+        for antenna in range(backend.num_antennas):
+            local_c_idx = antenna * selected_num_chans + np.arange(selected_num_chans)
+            input_c_idx = (
+                antenna * backend.num_chans
+                + relative_start_chan
+                + np.arange(selected_num_chans)
+            )
+            for pol in range(backend.num_pols):
+                t_idx = _get_time_indices(
+                    backend,
+                    subblock=subblock,
+                    bytes_per_subblock=plan.bytes_per_subblock,
+                    subblock_time_range=subblock_t_range,
+                    pol=pol,
+                )
+                v = _channelize_voltage(
+                    backend,
+                    antennas_v[antenna][pol],
+                    antenna=antenna,
+                    pol=pol,
+                    digitize=digitize,
+                    start_chan=absolute_start_chan,
+                    num_chans=selected_num_chans,
+                    coarse_method=spec.coarse_method,
+                )
+                if requantize:
+                    v = _requantize_voltage(
+                        backend,
+                        v,
+                        antenna=antenna,
+                        pol=pol,
+                        c_idx=input_c_idx,
+                        t_idx=t_idx,
+                        input_voltages=input_voltages,
+                        digitize=digitize,
+                        xp=xp,
+                    )
+                if rows_written is None:
+                    rows_written = v.shape[0]
+                block_voltages[
+                    row_offset:row_offset + v.shape[0],
+                    local_c_idx,
+                    pol,
+                ] = np.asarray(v, dtype=np.complex64)
+        row_offset += 0 if rows_written is None else rows_written
+
+    return block_voltages[:row_offset]
+
+
+def generate_voltage_spectrogram(
+    backend: Any,
+    spec: VoltageSpectrogramSpec,
+    *,
+    obs_length: float | None = None,
+    num_blocks: int | None = None,
+    length_mode: str = "obs_length",
+    digitize: bool = True,
+    requantize: bool = True,
+    verbose: bool = True,
+    xp: Any,
+) -> VoltageSpectrogramResult:
+    """Generate a spectrogram directly from a voltage backend.
+
+    Args:
+        backend: Configured :class:`RawVoltageBackend`.
+        spec: Spectrogram generation specification.
+        obs_length: Observation length in seconds.
+        num_blocks: Number of backend blocks to generate.
+        length_mode: Strategy for interpreting observation length inputs.
+        digitize: Whether to quantize input voltages before the PFB.
+        requantize: Whether to quantize complex post-PFB voltages.
+        verbose: Whether to emit progress output.
+        xp: Numerical array module used by the backend.
+
+    Returns:
+        Direct spectrogram result.
+    """
+    input_spec = _make_direct_input_spec(backend)
+    metadata = _build_reduction_metadata(input_spec, spec)
+    record_config = _RecordConfig.from_values(
+        obs_length=obs_length,
+        num_blocks=num_blocks,
+        length_mode=length_mode,
+        header_dict=None,
+        digitize=digitize,
+        load_template=False,
+        verbose=verbose,
+    )
+    backend.num_blocks = _resolve_num_blocks(
+        record_config.length,
+        get_num_blocks=backend.get_num_blocks,
+        fallback_num_blocks=backend.input_num_blocks,
+    )
+    if backend.input_num_blocks is not None:
+        backend.num_blocks = min(backend.num_blocks, backend.input_num_blocks)
+    backend.obs_length = backend.num_blocks * backend.time_per_block
+    backend.total_obs_num_samples = int(backend.obs_length / backend.tbin) * backend.num_branches
+
+    _reset_recording_state(backend)
+
+    channel_indices = None
+    full_fchans = metadata.num_chans * spec.fftlength
+    if metadata.channel_start != 0 or metadata.channel_stop != full_fchans:
+        channel_indices = np.arange(metadata.channel_start, metadata.channel_stop)
+
+    chunks: list[np.ndarray] = []
+    num_files = _get_num_output_files(backend, xp=xp)
+    for file_index in range(num_files):
+        blocks_to_write = _get_blocks_to_write(
+            backend,
+            file_index=file_index,
+            num_files=num_files,
+        )
+        input_context = nullcontext(None)
+        if backend.input_file_stem is not None:
+            input_context = open(f"{backend.input_file_stem}.{file_index:04}.raw", "rb")
+        with input_context as input_file_handler:
+            backend.input_file_handler = input_file_handler
+            for _ in range(blocks_to_write):
+                coarse_voltages = _collect_coarse_voltage_block(
+                    backend,
+                    metadata=metadata,
+                    spec=spec,
+                    digitize=digitize,
+                    requantize=requantize,
+                    verbose=verbose,
+                    xp=xp,
+                )
+                reduced = _channelize_block(
+                    coarse_voltages,
+                    fftlength=spec.fftlength,
+                    integration_factor=spec.integration_factor,
+                    pol_mode=spec.pol_mode,
+                    backend=spec.backend,
+                    channel_indices=channel_indices,
+                    fine_method=spec.fine_method,
+                )
+                if reduced is not None and reduced.shape[0] > 0:
+                    chunks.append(reduced)
+            backend.input_file_handler = None
+
+    if not chunks:
+        raise ValueError("No spectra were produced from the supplied voltage settings.")
+    return VoltageSpectrogramResult(
+        data=np.concatenate(chunks, axis=0),
+        metadata=metadata,
+        spec=spec,
+        input_spec=input_spec,
+    )

--- a/setigen/voltage/spectrogram.py
+++ b/setigen/voltage/spectrogram.py
@@ -198,6 +198,14 @@ def _make_direct_input_spec(backend: Any) -> Any:
     )
 
 
+def _to_host_array(array: Any, *, xp: Any) -> Any:
+    """Return an array on the host, copying from CuPy when needed."""
+    try:
+        return xp.asnumpy(array)
+    except AttributeError:
+        return array
+
+
 def _collect_coarse_voltage_block(
     backend: Any,
     *,
@@ -299,7 +307,7 @@ def _collect_coarse_voltage_block(
                     row_offset:row_offset + v.shape[0],
                     local_c_idx,
                     pol,
-                ] = np.asarray(v, dtype=np.complex64)
+                ] = np.asarray(_to_host_array(v, xp=xp), dtype=np.complex64)
         row_offset += 0 if rows_written is None else rows_written
 
     return block_voltages[:row_offset]

--- a/setigen/voltage/spectrogram.py
+++ b/setigen/voltage/spectrogram.py
@@ -199,7 +199,15 @@ def _make_direct_input_spec(backend: Any) -> Any:
 
 
 def _to_host_array(array: Any, *, xp: Any) -> Any:
-    """Return an array on the host, copying from CuPy when needed."""
+    """Return an array on the host, copying from CuPy when needed.
+
+    Args:
+        array: NumPy-like or CuPy-like array.
+        xp: Numerical array module used to create ``array``.
+
+    Returns:
+        Host-side array when ``xp`` supports GPU arrays; otherwise ``array``.
+    """
     try:
         return xp.asnumpy(array)
     except AttributeError:

--- a/setigen/voltage/waterfall.py
+++ b/setigen/voltage/waterfall.py
@@ -1,18 +1,8 @@
 from __future__ import annotations
 
-import os
-
-GPU_FLAG = os.getenv('SETIGEN_ENABLE_GPU', '0')
-if GPU_FLAG == '1':
-    try:
-        import cupy as xp
-    except ImportError:
-        import numpy as xp
-else:
-    import numpy as xp
-    
 import numpy as np
 
+from ._array_backend import xp
 from ._reduction.channelize import _channelize_block
 from ._reduction.decoder import _decode_raw_block
 from ._reduction.input import _resolve_raw_input

--- a/tests/test_voltage/test_array_backend.py
+++ b/tests/test_voltage/test_array_backend.py
@@ -4,6 +4,19 @@ import numpy as np
 import pytest
 
 import setigen as stg
+from setigen.voltage import _array_backend
+
+
+class _FakeCupyModule:
+    __name__ = "cupy"
+
+    @staticmethod
+    def asarray(array):
+        return np.asarray(array)
+
+    @staticmethod
+    def asnumpy(array):
+        return np.asarray(array)
 
 
 def test_set_backend_numpy_forces_numpy():
@@ -31,3 +44,48 @@ def test_set_backend_cupy_validates_import():
             assert stg.voltage.get_backend() == "cupy"
     finally:
         stg.voltage.set_backend("numpy")
+
+
+def test_auto_backend_env_falls_back_to_numpy_when_cupy_missing(monkeypatch):
+    monkeypatch.setenv("SETIGEN_ENABLE_GPU", "1")
+    monkeypatch.delitem(_array_backend._modules, "cupy", raising=False)
+    monkeypatch.setattr(_array_backend.importlib, "import_module", lambda name: (_ for _ in ()).throw(ImportError()))
+
+    stg.voltage.set_backend("auto")
+
+    assert _array_backend.get_array_module("auto") is np
+    assert stg.voltage.get_backend() == "numpy"
+
+
+def test_array_backend_proxy_and_asnumpy_use_active_module(monkeypatch):
+    fake_cupy = _FakeCupyModule()
+    monkeypatch.setitem(_array_backend._modules, "cupy", fake_cupy)
+    stg.voltage.set_backend("cupy")
+    try:
+        assert _array_backend.xp.__name__ == "cupy"
+        assert _array_backend.xp.asarray([1]).shape == (1,)
+        assert repr(_array_backend.xp) == repr(fake_cupy)
+        assert np.array_equal(_array_backend.asnumpy([1, 2, 3]), np.array([1, 2, 3]))
+    finally:
+        stg.voltage.set_backend("numpy")
+
+
+def test_array_backend_numpy_helpers(monkeypatch):
+    monkeypatch.delenv("SETIGEN_ENABLE_GPU", raising=False)
+    stg.voltage.set_backend("auto")
+
+    assert _array_backend.get_array_module() is np
+    assert _array_backend.get_array_module("numpy") is np
+    assert np.array_equal(_array_backend.asnumpy([4, 5]), np.array([4, 5]))
+
+
+def test_get_array_module_explicit_cupy_raises_when_missing(monkeypatch):
+    monkeypatch.delitem(_array_backend._modules, "cupy", raising=False)
+    monkeypatch.setattr(
+        _array_backend.importlib,
+        "import_module",
+        lambda name: (_ for _ in ()).throw(ImportError()),
+    )
+
+    with pytest.raises(ImportError, match="CuPy backend requested"):
+        _array_backend.get_array_module("cupy")

--- a/tests/test_voltage/test_array_backend.py
+++ b/tests/test_voltage/test_array_backend.py
@@ -1,0 +1,33 @@
+import importlib.util
+
+import numpy as np
+import pytest
+
+import setigen as stg
+
+
+def test_set_backend_numpy_forces_numpy():
+    stg.voltage.set_backend("numpy")
+
+    stream = stg.voltage.DataStream(seed=0)
+    samples = stream.get_samples(8)
+
+    assert stg.voltage.get_backend() == "numpy"
+    assert isinstance(samples, np.ndarray)
+
+
+def test_set_backend_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="backend must be"):
+        stg.voltage.set_backend("not-a-backend")
+
+
+def test_set_backend_cupy_validates_import():
+    try:
+        if importlib.util.find_spec("cupy") is None:
+            with pytest.raises(ImportError, match="CuPy backend requested"):
+                stg.voltage.set_backend("cupy")
+        else:
+            stg.voltage.set_backend("cupy")
+            assert stg.voltage.get_backend() == "cupy"
+    finally:
+        stg.voltage.set_backend("numpy")

--- a/tests/test_voltage/test_pfb.py
+++ b/tests/test_voltage/test_pfb.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 import setigen as stg
+from setigen.voltage.polyphase_filterbank import pfb_frontend, pfb_frontend_reference
 
 
 def test_filterbank():
@@ -35,5 +36,72 @@ def test_pfb_voltages():
                                                           num_branches=num_branches)
     
     assert_allclose(np.abs(X_f), np.abs(X)[:, :-1])
+
+
+def test_vectorized_pfb_frontend_matches_reference():
+    rng = np.random.default_rng(123)
+    num_taps = 4
+    num_branches = 32
+    filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                 num_branches=num_branches)
+    samples = rng.standard_normal(num_taps * num_branches * 5)
+
+    expected = pfb_frontend_reference(samples,
+                                      filterbank.window,
+                                      num_taps,
+                                      num_branches)
+    actual = pfb_frontend(samples,
+                          filterbank.window,
+                          num_taps,
+                          num_branches)
+
+    assert_allclose(actual, expected)
+
+
+def test_selected_coarse_channelize_matches_full_slice():
+    rng = np.random.default_rng(321)
+    num_taps = 4
+    num_branches = 64
+    samples = rng.standard_normal(num_taps * num_branches * 6)
+
+    full_filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                      num_branches=num_branches)
+    selected_filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                          num_branches=num_branches)
+
+    full = full_filterbank.channelize(samples,
+                                      cache=False,
+                                      method="full")
+    selected = selected_filterbank.channelize(samples,
+                                             cache=False,
+                                             start_chan=3,
+                                             num_chans=4,
+                                             method="selected")
+
+    assert_allclose(selected, full[:, 3:7], rtol=1e-12, atol=1e-12)
+
+
+def test_selected_coarse_channelize_drifting_tone_matches_full_slice():
+    num_taps = 4
+    num_branches = 64
+    num_samples = num_taps * num_branches * 6
+    ts = np.arange(num_samples) / 3e9
+    tone = np.cos(2 * np.pi * (1.5e8 * ts + 0.5 * 5e5 * ts**2))
+
+    full_filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                      num_branches=num_branches)
+    selected_filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                          num_branches=num_branches)
+
+    full = full_filterbank.channelize(tone,
+                                      cache=False,
+                                      method="full")
+    selected = selected_filterbank.channelize(tone,
+                                             cache=False,
+                                             start_chan=1,
+                                             num_chans=2,
+                                             method="selected")
+
+    assert_allclose(selected, full[:, 1:3], rtol=1e-12, atol=1e-12)
 
     

--- a/tests/test_voltage/test_pfb.py
+++ b/tests/test_voltage/test_pfb.py
@@ -53,7 +53,29 @@ def test_vectorized_pfb_frontend_matches_reference():
     actual = pfb_frontend(samples,
                           filterbank.window,
                           num_taps,
-                          num_branches)
+                          num_branches,
+                          method="vectorized")
+
+    assert_allclose(actual, expected)
+
+
+def test_pfb_frontend_auto_matches_reference():
+    rng = np.random.default_rng(124)
+    num_taps = 4
+    num_branches = 32
+    filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                 num_branches=num_branches)
+    samples = rng.standard_normal(num_taps * num_branches * 5)
+
+    expected = pfb_frontend_reference(samples,
+                                      filterbank.window,
+                                      num_taps,
+                                      num_branches)
+    actual = pfb_frontend(samples,
+                          filterbank.window,
+                          num_taps,
+                          num_branches,
+                          method="auto")
 
     assert_allclose(actual, expected)
 

--- a/tests/test_voltage/test_pfb.py
+++ b/tests/test_voltage/test_pfb.py
@@ -16,6 +16,14 @@ def test_filterbank():
     assert len(filterbank.tile_response(num_chans=64, fftlength=512)) == 64 * 512
 
 
+def test_filterbank_rejects_response_fftlength_not_multiple_of_taps():
+    filterbank = stg.voltage.PolyphaseFilterbank(num_taps=8,
+                                                 num_branches=64)
+
+    with pytest.raises(ValueError, match="must be a multiple"):
+        filterbank.get_response(fftlength=10)
+
+
 def test_pfb_voltages():
     antenna = stg.voltage.Antenna(sample_rate=3e9, 
                                   fch1=6e9,
@@ -126,4 +134,37 @@ def test_selected_coarse_channelize_drifting_tone_matches_full_slice():
 
     assert_allclose(selected, full[:, 1:3], rtol=1e-12, atol=1e-12)
 
-    
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"method": "bad"}, "method must be"),
+        ({"start_chan": -1}, "start_chan must be"),
+        ({"start_chan": 0, "num_chans": 0}, "out of bounds"),
+        ({"start_chan": 33, "num_chans": 1}, "out of bounds"),
+    ],
+)
+def test_channelize_rejects_invalid_selection(kwargs, message):
+    num_taps = 4
+    num_branches = 64
+    samples = np.ones(num_taps * num_branches * 4)
+    filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                 num_branches=num_branches)
+
+    with pytest.raises(ValueError, match=message):
+        filterbank.channelize(samples, cache=False, **kwargs)
+
+
+def test_pfb_frontend_rejects_unknown_method():
+    num_taps = 4
+    num_branches = 32
+    filterbank = stg.voltage.PolyphaseFilterbank(num_taps=num_taps,
+                                                 num_branches=num_branches)
+    samples = np.ones(num_taps * num_branches * 4)
+
+    with pytest.raises(ValueError, match="method must be"):
+        pfb_frontend(samples,
+                     filterbank.window,
+                     num_taps,
+                     num_branches,
+                     method="bad")

--- a/tests/test_voltage/test_reduction.py
+++ b/tests/test_voltage/test_reduction.py
@@ -1,3 +1,5 @@
+import importlib.util
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -8,6 +10,19 @@ import setigen as stg
 from setigen.voltage._reduction.channelize import _channelize_block
 from setigen.voltage._reduction.decoder import _decode_raw_block
 from setigen.voltage.reduction import _reduce_chunks
+
+
+def _require_cupy_device():
+    if importlib.util.find_spec("cupy") is None:
+        pytest.skip("CuPy is not installed.")
+    cupy = pytest.importorskip("cupy")
+    try:
+        device_count = cupy.cuda.runtime.getDeviceCount()
+    except Exception as exc:
+        pytest.skip(f"CuPy CUDA runtime is unavailable: {exc}")
+    if device_count < 1:
+        pytest.skip("No CUDA devices available.")
+    return cupy
 
 
 def _make_backend(*,
@@ -391,6 +406,33 @@ def test_direct_spectrogram_matches_raw_roundtrip_total_power(tmp_path):
 
     assert direct_frame.data.shape == raw_frame.data.shape
     assert_allclose(direct_frame.data, raw_frame.data)
+
+
+def test_direct_spectrogram_cupy_backend_smoke():
+    _require_cupy_device()
+    try:
+        stg.voltage.set_backend("cupy")
+        backend = _make_backend(num_pols=2,
+                                num_bits=8,
+                                num_chans=4,
+                                fftlength=8,
+                                tchans_per_block=8)
+        spec = stg.voltage.VoltageSpectrogramSpec(fftlength=8,
+                                                  integration_factor=1,
+                                                  pol_mode=1,
+                                                  backend="cupy",
+                                                  coarse_method="full",
+                                                  fine_method="full")
+
+        result = backend.to_spectrogram(spec,
+                                        num_blocks=1,
+                                        length_mode="num_blocks",
+                                        verbose=False)
+
+        assert result.data.shape == (8, 1, 32)
+        assert np.isfinite(result.data).all()
+    finally:
+        stg.voltage.set_backend("numpy")
 
 
 def test_direct_spectrogram_frequency_range_matches_full_direct():

--- a/tests/test_voltage/test_reduction.py
+++ b/tests/test_voltage/test_reduction.py
@@ -1,4 +1,5 @@
 import importlib.util
+from types import SimpleNamespace
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -7,9 +8,14 @@ from astropy import units as u
 from blimpy import Waterfall
 
 import setigen as stg
+import setigen.voltage._reduction.channelize as channelize_module
+import setigen.voltage.reduction as reduction_module
+import setigen.voltage.spectrogram as spectrogram_module
+from setigen.voltage._reduction.metadata import _ReductionMetadata, _build_reduction_metadata
 from setigen.voltage._reduction.channelize import _channelize_block
 from setigen.voltage._reduction.decoder import _decode_raw_block
 from setigen.voltage.reduction import _reduce_chunks
+from setigen.voltage.spectrogram import _to_host_array
 
 
 def _require_cupy_device():
@@ -225,6 +231,61 @@ def test_channelize_block_selected_fine_full_stokes_matches_full_slice():
     assert_allclose(selected, full[:, :, selected_indices], rtol=1e-6, atol=1e-6)
 
 
+def test_channelize_block_auto_and_full_slice_channel_selection():
+    rng = np.random.default_rng(24)
+    voltages = (
+        rng.standard_normal((16, 3, 2))
+        + 1j * rng.standard_normal((16, 3, 2))
+    ).astype(np.complex64)
+    selected_indices = np.arange(2, 8)
+
+    full_total = _channelize_block(voltages,
+                                   fftlength=4,
+                                   integration_factor=2,
+                                   pol_mode=1,
+                                   backend="numpy",
+                                   fine_method="full")
+    auto_selected = _channelize_block(voltages,
+                                      fftlength=4,
+                                      integration_factor=2,
+                                      pol_mode=1,
+                                      backend="numpy",
+                                      channel_indices=selected_indices)
+    full_selected = _channelize_block(voltages,
+                                      fftlength=4,
+                                      integration_factor=2,
+                                      pol_mode=1,
+                                      backend="numpy",
+                                      channel_indices=selected_indices,
+                                      fine_method="full")
+    full_stokes = _channelize_block(voltages,
+                                    fftlength=4,
+                                    integration_factor=2,
+                                    pol_mode=-4,
+                                    backend="numpy",
+                                    fine_method="full")
+    full_stokes_selected = _channelize_block(voltages,
+                                             fftlength=4,
+                                             integration_factor=2,
+                                             pol_mode=-4,
+                                             backend="numpy",
+                                             channel_indices=selected_indices,
+                                             fine_method="full")
+
+    assert_allclose(auto_selected[:, 0, :],
+                    full_total[:, 0, selected_indices],
+                    rtol=1e-6,
+                    atol=1e-6)
+    assert_allclose(full_selected[:, 0, :],
+                    full_total[:, 0, selected_indices],
+                    rtol=1e-6,
+                    atol=1e-6)
+    assert_allclose(full_stokes_selected,
+                    full_stokes[:, :, selected_indices],
+                    rtol=1e-6,
+                    atol=1e-6)
+
+
 def test_channelize_block_rejects_full_pol_single_pol_input():
     voltages = np.ones((4, 1, 1), dtype=np.complex64)
 
@@ -234,6 +295,384 @@ def test_channelize_block_rejects_full_pol_single_pol_input():
                           integration_factor=1,
                           pol_mode=4,
                           backend="numpy")
+
+
+def test_channelize_block_edge_cases():
+    voltages = np.ones((3, 1, 2), dtype=np.complex64)
+
+    with pytest.raises(ValueError, match="fine_method must be"):
+        _channelize_block(voltages,
+                          fftlength=2,
+                          integration_factor=1,
+                          pol_mode=1,
+                          backend="numpy",
+                          fine_method="bad")
+
+    with pytest.raises(ValueError, match="out of bounds"):
+        _channelize_block(voltages,
+                          fftlength=2,
+                          integration_factor=1,
+                          pol_mode=1,
+                          backend="numpy",
+                          channel_indices=[2],
+                          fine_method="selected")
+
+    with pytest.raises(ValueError, match="Unsupported reduction backend"):
+        _channelize_block(voltages,
+                          fftlength=2,
+                          integration_factor=1,
+                          pol_mode=1,
+                          backend="bad")
+
+    with pytest.raises(ValueError, match="Unsupported polarization mode"):
+        _channelize_block(voltages,
+                          fftlength=2,
+                          integration_factor=1,
+                          pol_mode=2,
+                          backend="numpy")
+
+    assert _channelize_block(voltages[:1],
+                             fftlength=2,
+                             integration_factor=1,
+                             pol_mode=1,
+                             backend="numpy") is None
+    assert _channelize_block(voltages[:1],
+                             fftlength=2,
+                             integration_factor=1,
+                             pol_mode=1,
+                             backend="numpy",
+                             channel_indices=[0],
+                             fine_method="selected") is None
+    assert _channelize_block(voltages,
+                             fftlength=2,
+                             integration_factor=2,
+                             pol_mode=1,
+                             backend="numpy") is None
+    assert _channelize_block(voltages,
+                             fftlength=2,
+                             integration_factor=1,
+                             pol_mode=1,
+                             backend="numpy",
+                             channel_indices=[],
+                             fine_method="selected") is None
+    assert _channelize_block(np.ones((2, 1, 2), dtype=np.complex64),
+                             fftlength=2,
+                             integration_factor=2,
+                             pol_mode=-4,
+                             backend="numpy") is None
+
+
+def test_channelize_block_converts_non_numpy_backend_to_host(monkeypatch):
+    class FakeArrayModule:
+        __name__ = "fake"
+        fft = np.fft
+        newaxis = np.newaxis
+        pi = np.pi
+
+        @staticmethod
+        def asarray(array):
+            return np.asarray(array)
+
+        @staticmethod
+        def asnumpy(array):
+            return np.asarray(array)
+
+        @staticmethod
+        def abs(array):
+            return np.abs(array)
+
+    monkeypatch.setattr(channelize_module,
+                        "_get_array_module",
+                        lambda backend: FakeArrayModule)
+    voltages = np.ones((4, 1, 1), dtype=np.complex64)
+
+    reduced = _channelize_block(voltages,
+                                fftlength=2,
+                                integration_factor=1,
+                                pol_mode=1,
+                                backend="fake")
+
+    assert isinstance(reduced, np.ndarray)
+    assert reduced.dtype == np.float32
+
+
+def test_reduction_specs_reject_invalid_new_options():
+    base_kwargs = {
+        "fftlength": 8,
+        "integration_factor": 1,
+        "pol_mode": 1,
+        "output_format": "fil",
+    }
+
+    invalid_kwargs = [
+        {"fftlength": 0, "match": "fftlength"},
+        {"integration_factor": 0, "match": "integration_factor"},
+        {"pol_mode": 2, "match": "polarization"},
+        {"output_format": "bad", "match": "output format"},
+        {"backend": "bad", "match": "backend"},
+        {"accuracy": "bad", "match": "accuracy"},
+        {"accuracy": "approx_zoom", "match": "accuracy='exact'"},
+        {"coarse_method": "bad", "match": "coarse method"},
+        {"fine_method": "bad", "match": "fine method"},
+        {"start_chan": -1, "match": "start_chan"},
+        {"num_chans": 0, "match": "num_chans"},
+        {"frequency_range": (1.0, 2.0), "start_chan": 0, "match": "mutually exclusive"},
+        {"frequency_range": (1.0, 2.0, 3.0), "match": "exactly two"},
+    ]
+    for params in invalid_kwargs:
+        kwargs = dict(params)
+        match = kwargs.pop("match")
+        with pytest.raises(ValueError, match=match):
+            stg.voltage.RawReductionSpec(**{**base_kwargs, **kwargs})
+
+    spectrogram_base = {
+        "fftlength": 8,
+        "integration_factor": 1,
+        "pol_mode": 1,
+    }
+    for params in invalid_kwargs:
+        if "output_format" in params:
+            continue
+        kwargs = dict(params)
+        match = kwargs.pop("match")
+        with pytest.raises(ValueError, match=match):
+            stg.voltage.VoltageSpectrogramSpec(**{**spectrogram_base, **kwargs})
+
+
+def test_build_reduction_metadata_frequency_range_and_bounds():
+    input_spec = SimpleNamespace(
+        num_chans=4,
+        chan_bw=8.0,
+        tbin=0.5,
+        fch1=100.0,
+        ascending=True,
+    )
+    spec = stg.voltage.RawReductionSpec(fftlength=4,
+                                        integration_factor=2,
+                                        pol_mode=1,
+                                        output_format="fil",
+                                        frequency_range=(99.0, 105.0))
+
+    metadata = _build_reduction_metadata(input_spec, spec)
+
+    assert metadata.channel_start == 2
+    assert metadata.channel_stop == 5
+    assert metadata.total_fchans == 3
+    assert metadata.fch1_hz == pytest.approx(100.0)
+
+    out_of_range = stg.voltage.RawReductionSpec(fftlength=4,
+                                                integration_factor=2,
+                                                pol_mode=1,
+                                                output_format="fil",
+                                                frequency_range=(1.0, 2.0))
+    with pytest.raises(ValueError, match="does not overlap"):
+        _build_reduction_metadata(input_spec, out_of_range)
+
+    coarse_out_of_bounds = stg.voltage.RawReductionSpec(fftlength=4,
+                                                        integration_factor=2,
+                                                        pol_mode=1,
+                                                        output_format="fil",
+                                                        start_chan=4,
+                                                        num_chans=1)
+    with pytest.raises(ValueError, match="out of bounds"):
+        _build_reduction_metadata(input_spec, coarse_out_of_bounds)
+
+    conflicting = SimpleNamespace(start_chan=0,
+                                  num_chans=None,
+                                  frequency_range=(1.0, 2.0),
+                                  pol_mode=1,
+                                  fftlength=4,
+                                  integration_factor=2)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _build_reduction_metadata(input_spec, conflicting)
+
+
+def test_voltage_spectrogram_result_error_paths(tmp_path):
+    metadata = _ReductionMetadata(start_chan=0,
+                                  num_chans=1,
+                                  nifs=4,
+                                  df_hz=1.0,
+                                  dt_s=1.0,
+                                  fch1_hz=100.0,
+                                  ascending=True,
+                                  total_fchans=4)
+    result = stg.voltage.VoltageSpectrogramResult(
+        data=np.zeros((1, 4, 4), dtype=np.float32),
+        metadata=metadata,
+        spec=stg.voltage.VoltageSpectrogramSpec(fftlength=4,
+                                                integration_factor=1,
+                                                pol_mode=-4),
+        input_spec=SimpleNamespace(),
+    )
+
+    with pytest.raises(ValueError, match="to_frame only supports"):
+        result.to_frame()
+    with pytest.raises(ValueError, match="output_format must be supplied"):
+        result.write(tmp_path / "spectrogram.txt")
+
+
+def test_voltage_spectrogram_result_write_infers_supported_suffixes(monkeypatch, tmp_path):
+    class DummyWriter:
+        def __init__(self):
+            self.appended = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def append(self, data):
+            self.appended.append(data)
+
+    writers = []
+
+    def create_writer(*args, **kwargs):
+        writer = DummyWriter()
+        writers.append((writer, kwargs["output_format"]))
+        return writer
+
+    monkeypatch.setattr(spectrogram_module,
+                        "_build_filterbank_header",
+                        lambda *args, **kwargs: {})
+    monkeypatch.setattr(spectrogram_module, "_create_writer", create_writer)
+    metadata = _ReductionMetadata(start_chan=0,
+                                  num_chans=1,
+                                  nifs=1,
+                                  df_hz=1.0,
+                                  dt_s=1.0,
+                                  fch1_hz=100.0,
+                                  ascending=True,
+                                  total_fchans=4)
+    result = stg.voltage.VoltageSpectrogramResult(
+        data=np.zeros((1, 1, 4), dtype=np.float32),
+        metadata=metadata,
+        spec=stg.voltage.VoltageSpectrogramSpec(fftlength=4,
+                                                integration_factor=1,
+                                                pol_mode=1),
+        input_spec=SimpleNamespace(),
+    )
+
+    assert result.write(tmp_path / "spectrogram.fil") == tmp_path / "spectrogram.fil"
+    assert result.write(tmp_path / "spectrogram.h5") == tmp_path / "spectrogram.h5"
+    assert [output_format for _, output_format in writers] == ["fil", "h5"]
+    assert all(writer.appended for writer, _ in writers)
+
+
+def test_raw_reduction_no_output_error_paths(monkeypatch, tmp_path):
+    spec = stg.voltage.RawReductionSpec(fftlength=4,
+                                        integration_factor=1,
+                                        pol_mode=1,
+                                        output_format="fil")
+    monkeypatch.setattr(reduction_module,
+                        "_reduce_chunks",
+                        lambda input_path, spec, max_blocks=None: iter(()))
+
+    with pytest.raises(ValueError, match="No spectra were produced"):
+        reduction_module.reduce_raw(tmp_path / "missing.raw",
+                                    tmp_path / "missing.fil",
+                                    spec)
+    with pytest.raises(ValueError, match="No frame data"):
+        reduction_module.reduce_raw_to_frame(tmp_path / "missing.raw", spec)
+
+    full_stokes = stg.voltage.RawReductionSpec(fftlength=4,
+                                               integration_factor=1,
+                                               pol_mode=-4,
+                                               output_format="fil")
+    with pytest.raises(ValueError, match="only supports total-power"):
+        reduction_module.reduce_raw_to_frame(tmp_path / "missing.raw", full_stokes)
+
+
+def test_generate_voltage_spectrogram_raises_when_no_chunks(monkeypatch):
+    backend = SimpleNamespace(
+        num_chans=1,
+        num_pols=2,
+        num_bits=8,
+        chan_bw=8.0,
+        tbin=0.5,
+        fch1=100.0,
+        start_chan=0,
+        ascending=True,
+        input_num_blocks=None,
+        input_file_stem=None,
+        time_per_block=1.0,
+        num_branches=1,
+        get_num_blocks=lambda length: 1,
+    )
+    metadata = _ReductionMetadata(start_chan=0,
+                                  num_chans=1,
+                                  nifs=1,
+                                  df_hz=1.0,
+                                  dt_s=1.0,
+                                  fch1_hz=100.0,
+                                  ascending=True,
+                                  total_fchans=4)
+
+    monkeypatch.setattr(spectrogram_module,
+                        "_build_reduction_metadata",
+                        lambda input_spec, spec: metadata)
+    monkeypatch.setattr(spectrogram_module._RecordConfig,
+                        "from_values",
+                        lambda **kwargs: SimpleNamespace(length=1))
+    monkeypatch.setattr(spectrogram_module, "_resolve_num_blocks", lambda *args, **kwargs: 1)
+    monkeypatch.setattr(spectrogram_module, "_reset_recording_state", lambda backend: None)
+    monkeypatch.setattr(spectrogram_module, "_get_num_output_files", lambda backend, xp: 1)
+    monkeypatch.setattr(spectrogram_module,
+                        "_get_blocks_to_write",
+                        lambda backend, file_index, num_files: 1)
+    monkeypatch.setattr(spectrogram_module,
+                        "_collect_coarse_voltage_block",
+                        lambda *args, **kwargs: np.ones((4, 1, 2), dtype=np.complex64))
+    monkeypatch.setattr(spectrogram_module, "_channelize_block", lambda *args, **kwargs: None)
+
+    with pytest.raises(ValueError, match="No spectra were produced"):
+        spectrogram_module.generate_voltage_spectrogram(
+            backend,
+            stg.voltage.VoltageSpectrogramSpec(fftlength=4, integration_factor=1),
+            num_blocks=1,
+            length_mode="num_blocks",
+            verbose=False,
+            xp=np,
+        )
+
+
+def test_collect_coarse_voltage_block_requires_requantize_for_raw_input(monkeypatch):
+    backend = SimpleNamespace(num_chans=1,
+                              num_antennas=1,
+                              num_pols=2,
+                              input_file_stem="input")
+    metadata = SimpleNamespace(num_chans=1, start_chan=0)
+    spec = stg.voltage.VoltageSpectrogramSpec(fftlength=4,
+                                              integration_factor=1)
+    monkeypatch.setattr(spectrogram_module,
+                        "_plan_subblocks",
+                        lambda backend, obsnchan: SimpleNamespace(
+                            num_subblocks=1,
+                            total_time_samples=1,
+                            bytes_per_subblock=1,
+                        ))
+
+    with pytest.raises(ValueError, match="requantize=True"):
+        spectrogram_module._collect_coarse_voltage_block(
+            backend,
+            metadata=metadata,
+            spec=spec,
+            digitize=True,
+            requantize=False,
+            verbose=False,
+            xp=np,
+        )
+
+
+def test_to_host_array_uses_backend_asnumpy():
+    class FakeArrayModule:
+        @staticmethod
+        def asnumpy(array):
+            return np.asarray(array) + 1
+
+    assert np.array_equal(_to_host_array(np.array([1]), xp=FakeArrayModule), np.array([2]))
+    original = np.array([1])
+    assert _to_host_array(original, xp=np) is original
 
 
 def test_reduce_raw_to_frame_matches_existing_helper(tmp_path):

--- a/tests/test_voltage/test_reduction.py
+++ b/tests/test_voltage/test_reduction.py
@@ -7,6 +7,7 @@ from blimpy import Waterfall
 import setigen as stg
 from setigen.voltage._reduction.channelize import _channelize_block
 from setigen.voltage._reduction.decoder import _decode_raw_block
+from setigen.voltage.reduction import _reduce_chunks
 
 
 def _make_backend(*,
@@ -159,6 +160,56 @@ def test_channelize_block_integrates_consecutive_fine_spectra():
     assert_allclose(reduced[:, 0, :], expected)
 
 
+def test_channelize_block_selected_fine_matches_full_slice():
+    rng = np.random.default_rng(22)
+    voltages = (
+        rng.standard_normal((16, 3, 2))
+        + 1j * rng.standard_normal((16, 3, 2))
+    ).astype(np.complex64)
+
+    full = _channelize_block(voltages,
+                             fftlength=4,
+                             integration_factor=2,
+                             pol_mode=1,
+                             backend="numpy",
+                             fine_method="full")
+    selected_indices = np.arange(3, 9)
+    selected = _channelize_block(voltages,
+                                 fftlength=4,
+                                 integration_factor=2,
+                                 pol_mode=1,
+                                 backend="numpy",
+                                 channel_indices=selected_indices,
+                                 fine_method="selected")
+
+    assert_allclose(selected[:, 0, :], full[:, 0, selected_indices], rtol=1e-6, atol=1e-6)
+
+
+def test_channelize_block_selected_fine_full_stokes_matches_full_slice():
+    rng = np.random.default_rng(23)
+    voltages = (
+        rng.standard_normal((16, 3, 2))
+        + 1j * rng.standard_normal((16, 3, 2))
+    ).astype(np.complex64)
+
+    full = _channelize_block(voltages,
+                             fftlength=4,
+                             integration_factor=2,
+                             pol_mode=-4,
+                             backend="numpy",
+                             fine_method="full")
+    selected_indices = np.arange(2, 10)
+    selected = _channelize_block(voltages,
+                                 fftlength=4,
+                                 integration_factor=2,
+                                 pol_mode=-4,
+                                 backend="numpy",
+                                 channel_indices=selected_indices,
+                                 fine_method="selected")
+
+    assert_allclose(selected, full[:, :, selected_indices], rtol=1e-6, atol=1e-6)
+
+
 def test_channelize_block_rejects_full_pol_single_pol_input():
     voltages = np.ones((4, 1, 1), dtype=np.complex64)
 
@@ -255,6 +306,38 @@ def test_reduce_raw_channel_subset_writes_consistent_filterbank_header(tmp_path)
     assert wf.data.shape == (4, 1, spec.fftlength)
 
 
+def test_reduce_raw_frequency_range_matches_full_fine_slice(tmp_path):
+    backend = _make_backend(num_pols=2, num_bits=8, num_chans=4, fftlength=8, tchans_per_block=8)
+    raw_stem = tmp_path / "fine_subset"
+
+    backend.record(output_file_stem=raw_stem,
+                   num_blocks=1,
+                   length_mode="num_blocks",
+                   verbose=False)
+
+    full_spec = stg.voltage.RawReductionSpec(fftlength=8,
+                                             integration_factor=1,
+                                             pol_mode=1,
+                                             output_format="fil")
+    full_frame = stg.voltage.reduce_raw_to_frame(raw_stem, full_spec)
+    start = 5
+    stop = 19
+    f0 = full_frame.fch1 + full_frame.df * start
+    f1 = full_frame.fch1 + full_frame.df * (stop - 1)
+    subset_spec = stg.voltage.RawReductionSpec(fftlength=8,
+                                               integration_factor=1,
+                                               pol_mode=1,
+                                               output_format="fil",
+                                               frequency_range=(f0, f1),
+                                               fine_method="selected")
+    subset_frame = stg.voltage.reduce_raw_to_frame(raw_stem, subset_spec)
+
+    assert subset_frame.data.shape == (full_frame.tchans, stop - start)
+    assert subset_frame.fch1 == pytest.approx(f0)
+    assert subset_frame.df == pytest.approx(full_frame.df)
+    assert_allclose(subset_frame.data, full_frame.data[:, start:stop], rtol=1e-6, atol=1e-6)
+
+
 def test_reduce_raw_roundtrip_fil_total_power(tmp_path):
     backend = _make_backend(num_pols=2, num_bits=8, num_chans=4, fftlength=8, tchans_per_block=8)
     raw_stem = tmp_path / "roundtrip_total"
@@ -279,6 +362,132 @@ def test_reduce_raw_roundtrip_fil_total_power(tmp_path):
     assert frame.data.shape == (16, 32)
     assert frame.fchans == 32
     assert frame.tchans == 16
+
+
+def test_direct_spectrogram_matches_raw_roundtrip_total_power(tmp_path):
+    raw_backend = _make_backend(num_pols=2, num_bits=8, num_chans=4, fftlength=8, tchans_per_block=8)
+    direct_backend = _make_backend(num_pols=2, num_bits=8, num_chans=4, fftlength=8, tchans_per_block=8)
+    raw_stem = tmp_path / "direct_total"
+
+    raw_backend.record(output_file_stem=raw_stem,
+                       num_blocks=1,
+                       length_mode="num_blocks",
+                       verbose=False)
+
+    raw_spec = stg.voltage.RawReductionSpec(fftlength=8,
+                                            integration_factor=1,
+                                            pol_mode=1,
+                                            output_format="fil")
+    direct_spec = stg.voltage.VoltageSpectrogramSpec(fftlength=8,
+                                                     integration_factor=1,
+                                                     pol_mode=1,
+                                                     coarse_method="full",
+                                                     fine_method="full")
+    raw_frame = stg.voltage.reduce_raw_to_frame(raw_stem, raw_spec)
+    direct_frame = direct_backend.to_spectrogram(direct_spec,
+                                                num_blocks=1,
+                                                length_mode="num_blocks",
+                                                verbose=False).to_frame()
+
+    assert direct_frame.data.shape == raw_frame.data.shape
+    assert_allclose(direct_frame.data, raw_frame.data)
+
+
+def test_direct_spectrogram_frequency_range_matches_full_direct():
+    full_backend = _make_backend(num_pols=2, num_bits=8, num_chans=4, fftlength=8, tchans_per_block=8)
+    subset_backend = _make_backend(num_pols=2, num_bits=8, num_chans=4, fftlength=8, tchans_per_block=8)
+
+    full_spec = stg.voltage.VoltageSpectrogramSpec(fftlength=8,
+                                                   integration_factor=1,
+                                                   pol_mode=1,
+                                                   coarse_method="full",
+                                                   fine_method="full")
+    full_result = full_backend.to_spectrogram(full_spec,
+                                             num_blocks=1,
+                                             length_mode="num_blocks",
+                                             verbose=False)
+    full_frame = full_result.to_frame()
+    start = 4
+    stop = 12
+    f0 = full_frame.fch1 + full_frame.df * start
+    f1 = full_frame.fch1 + full_frame.df * (stop - 1)
+    subset_spec = stg.voltage.VoltageSpectrogramSpec(fftlength=8,
+                                                     integration_factor=1,
+                                                     pol_mode=1,
+                                                     frequency_range=(f0, f1),
+                                                     coarse_method="full",
+                                                     fine_method="selected")
+    subset_frame = subset_backend.to_spectrogram(subset_spec,
+                                                num_blocks=1,
+                                                length_mode="num_blocks",
+                                                verbose=False).to_frame()
+
+    assert subset_frame.data.shape == (full_frame.tchans, stop - start)
+    assert subset_frame.fch1 == pytest.approx(f0)
+    assert subset_frame.df == pytest.approx(full_frame.df)
+    assert_allclose(subset_frame.data, full_frame.data[:, start:stop], rtol=1e-6, atol=1e-6)
+
+
+def test_direct_spectrogram_matches_raw_roundtrip_full_stokes_4bit(tmp_path):
+    raw_backend = _make_backend(num_pols=2, num_bits=4, num_chans=4, fftlength=8, tchans_per_block=8)
+    direct_backend = _make_backend(num_pols=2, num_bits=4, num_chans=4, fftlength=8, tchans_per_block=8)
+    raw_stem = tmp_path / "direct_stokes_4bit"
+
+    raw_backend.record(output_file_stem=raw_stem,
+                       num_blocks=1,
+                       length_mode="num_blocks",
+                       verbose=False)
+
+    raw_spec = stg.voltage.RawReductionSpec(fftlength=8,
+                                            integration_factor=1,
+                                            pol_mode=-4,
+                                            output_format="fil")
+    direct_spec = stg.voltage.VoltageSpectrogramSpec(fftlength=8,
+                                                     integration_factor=1,
+                                                     pol_mode=-4,
+                                                     coarse_method="full",
+                                                     fine_method="full")
+    raw_chunks = []
+    for chunk, _, _ in _reduce_chunks(raw_stem, raw_spec):
+        raw_chunks.append(chunk)
+    raw_data = np.concatenate(raw_chunks, axis=0)
+    direct_data = direct_backend.to_spectrogram(direct_spec,
+                                               num_blocks=1,
+                                               length_mode="num_blocks",
+                                               verbose=False).data
+
+    assert direct_data.shape == raw_data.shape
+    assert_allclose(direct_data, raw_data)
+
+
+def test_direct_spectrogram_from_data_shape(tmp_path):
+    base_backend = _make_backend(num_pols=2, num_bits=8, num_chans=4, fftlength=8, tchans_per_block=8)
+    raw_stem = tmp_path / "direct_from_data"
+    base_backend.record(output_file_stem=raw_stem,
+                        num_blocks=1,
+                        length_mode="num_blocks",
+                        verbose=False)
+
+    raw_params = stg.voltage.get_raw_params(input_file_stem=raw_stem,
+                                            start_chan=0)
+    antenna = stg.voltage.Antenna(sample_rate=base_backend.sample_rate,
+                                  seed=123,
+                                  **raw_params)
+    read_backend = stg.voltage.RawVoltageBackend.from_data(input_file_stem=raw_stem,
+                                                           antenna_source=antenna,
+                                                           start_chan=0,
+                                                           num_subblocks=4)
+    spec = stg.voltage.VoltageSpectrogramSpec(fftlength=8,
+                                              integration_factor=1,
+                                              pol_mode=1,
+                                              coarse_method="full",
+                                              fine_method="full")
+    result = read_backend.to_spectrogram(spec,
+                                         num_blocks=1,
+                                         length_mode="num_blocks",
+                                         verbose=False)
+
+    assert result.data.shape == (8, 1, 32)
 
 
 def test_reduce_raw_roundtrip_h5_total_power(tmp_path):


### PR DESCRIPTION
## Summary

This PR accelerates `setigen.voltage` workflows by adding exact selected-channel computation, direct voltage-to-spectrogram generation, and centralized NumPy/CuPy backend control.

Key changes:

- Add `stg.voltage.set_backend("cupy" | "numpy" | "auto")` for explicit backend selection.
- Keep `SETIGEN_ENABLE_GPU=1` as a legacy fallback.
- Add selected-bin coarse PFB channelization to avoid full coarse FFTs for small channel selections.
- Add selected fine-channel DFT reduction for targeted final-frequency regions.
- Add `RawVoltageBackend.to_spectrogram(...)` to generate spectrograms directly without writing and rereading RAW files.
- Add `frequency_range`, `coarse_method`, and `fine_method` options to reduction specs.
- Add CLI flags for `--frequency-range` and `--fine-method`.
- Update docs and voltage notebooks to prefer `stg.voltage.set_backend("cupy")`.

## Usage

Enable GPU acceleration before constructing voltage objects:

```python
import os
os.environ["CUDA_VISIBLE_DEVICES"] = "0"

import setigen as stg
stg.voltage.set_backend("cupy")
```

Force CPU execution:

```python
stg.voltage.set_backend("numpy")
```

Generate a spectrogram directly from a voltage backend:

```python
spec = stg.voltage.VoltageSpectrogramSpec(
    fftlength=1024,
    integration_factor=4,
    pol_mode=stg.voltage.PolarizationMode.TOTAL_POWER,
    coarse_method="auto",
    fine_method="auto",
)

result = rvb.to_spectrogram(
    spec,
    num_blocks=1,
    length_mode="num_blocks",
    verbose=False,
)

frame = result.to_frame()
```

Reduce only a final-frequency region:

```python
spec = stg.voltage.RawReductionSpec(
    fftlength=1024,
    integration_factor=4,
    pol_mode=stg.voltage.PolarizationMode.TOTAL_POWER,
    output_format="fil",
    frequency_range=(6001.0e6, 6001.5e6),
    backend="cupy",
    fine_method="selected",
)

stg.voltage.reduce_raw(raw_stem, "roi.fil", spec, overwrite=True)
```

CLI equivalent:

```bash
setigen-raw-reduce input.raw roi.fil \
  --fftlength 1024 \
  --integration-factor 4 \
  --frequency-range 6001000000 6001500000 \
  --backend cupy \
  --fine-method selected \
  --overwrite
```

## Notes

- The new selected-channel paths preserve exact FFT/DFT semantics.
- `accuracy="approx_zoom"` is reserved but not implemented; only `accuracy="exact"` is currently supported.
- `coarse_method="auto"` and `fine_method="auto"` use selected-bin computation only for small selections and fall back to full FFT otherwise.
- The tap-vectorized PFB frontend is available for experiments via `filterbank.frontend_method = "vectorized"`, but remains off by default because it can increase temporary memory use.
