### PR TITLE
Feature/20260426 overhaul i/o towards efficient injection

### DIFF
--- a/docs/plans/array_backend_acceleration.md
+++ b/docs/plans/array_backend_acceleration.md
@@ -1,0 +1,269 @@
+# Array Backend Acceleration Spec
+
+This spec defines one NumPy/CuPy policy for `setigen` so voltage synthesis,
+RAW reduction, eager `Frame` work, and file-backed spectrogram injection do not
+grow incompatible acceleration APIs.
+
+The existing voltage implementation is the starting point. It already has:
+
+- `ArrayBackend = Literal["auto", "numpy", "cupy"]`
+- `stg.voltage.set_backend(...)` and `stg.voltage.get_backend()`
+- lazy CuPy import and optional dependency behavior
+- legacy `SETIGEN_ENABLE_GPU=1` support
+- spec-level `backend` fields in `RawReductionSpec` and
+  `VoltageSpectrogramSpec`
+- an internal late-bound `xp` proxy for voltage internals
+
+The goal is to lift those conventions to a package-wide array backend layer,
+not to create a separate GPU API for `Frame` or file-backed mutation.
+
+## Vocabulary
+
+Use `array backend` for numerical compute backends:
+
+- `numpy`: CPU NumPy arrays.
+- `cupy`: GPU CuPy arrays.
+- `auto`: resolve through the package default and legacy environment policy.
+
+Use `storage backend`, `file backend`, or `spectrogram backend` for HDF5,
+filterbank, GUPPI RAW, and other file-backed I/O. Avoid using a bare
+implementation variable named `backend` when both meanings are in scope.
+
+Public APIs may keep a keyword named `backend` where the meaning is already
+array compute, especially in voltage specs and CLIs. New code that also handles
+storage should use `array_backend` internally or inside config objects.
+
+## Public API Policy
+
+Keep the existing voltage API working:
+
+```python
+stg.voltage.set_backend("cupy")
+stg.voltage.get_backend()
+```
+
+Add a package-level equivalent so non-voltage users do not have to configure a
+voltage namespace to accelerate `Frame` rendering:
+
+```python
+stg.set_backend("cupy")
+stg.get_backend()
+```
+
+`stg.voltage.set_backend()` and `stg.set_backend()` should delegate to the same
+global state. There must not be separate voltage and frame backend states.
+
+The package-level public surface should stay small:
+
+- `stg.set_backend(backend: Literal["auto", "numpy", "cupy"]) -> None`
+- `stg.get_backend() -> Literal["numpy", "cupy"]`
+
+Internal modules can use `setigen._array_backend` for:
+
+- `ArrayBackend`
+- `get_array_module(backend=None)`
+- `to_numpy(array, xp=None)`
+- an internal `xp` proxy when late binding is appropriate
+
+Do not expose a public `stg.xp` proxy initially. It encourages hidden global
+behavior in user code and makes callables harder to reason about.
+
+## Resolution Semantics
+
+Resolution must be identical across voltage, frame, and file-backed paths:
+
+- `backend="numpy"` always uses NumPy.
+- `backend="cupy"` requires CuPy and raises `ImportError` if CuPy is missing.
+- `backend="auto"` follows the package default.
+- The package default starts as `"auto"` for compatibility.
+- Default `"auto"` follows `SETIGEN_ENABLE_GPU=1`; if CuPy is unavailable in
+  this legacy auto mode, it falls back to NumPy.
+- Explicit `"cupy"` never falls back silently.
+- Operation-level `backend=` overrides the package default for that operation.
+
+`get_backend()` should return the active concrete backend, either `"numpy"` or
+`"cupy"`, matching the current voltage behavior.
+
+Do not overload `auto` with performance heuristics. If we later decide that
+tiny chunks should stay on CPU to avoid transfer overhead, that should be a
+separate policy knob such as `gpu_min_elements`, not a changed meaning of
+`backend="auto"`.
+
+## Array Ownership And Transfers
+
+Public data products remain host NumPy arrays unless an API explicitly says
+otherwise.
+
+This means:
+
+- `Frame.data` is NumPy.
+- `Frame.read_frame(...).data` is NumPy.
+- `VoltageSpectrogramResult.data` is NumPy.
+- file-backed `read_region()` and `write_region()` exchange NumPy arrays.
+- plotting receives NumPy arrays.
+
+Internal compute kernels may use CuPy arrays. The transfer boundary is explicit:
+
+1. read or create a NumPy chunk
+2. transfer to the selected array backend with `xp.asarray(...)`
+3. render, add, channelize, or reduce on that backend
+4. transfer back with `to_numpy(...)` before file writes, plotting, or public
+   `Frame` materialization
+
+The current voltage helper `asnumpy()` should become `to_numpy(array, xp=None)`.
+It should prefer an explicit `xp` argument when available and otherwise inspect
+the array/module safely. This avoids converting with the current global backend
+when an array was produced by a different backend.
+
+## Frame And Signal Rendering Policy
+
+`Frame.add_signal()` should eventually accept the same array backend vocabulary:
+
+```python
+frame.add_signal(..., backend="auto")
+```
+
+For classes or config objects where `backend` would be ambiguous, use
+`array_backend`:
+
+```python
+SignalRenderConfig(array_backend="auto", compute_dtype=None)
+```
+
+Implementation should split signal rendering from mutation before adding GPU
+support:
+
+- A renderer builds the signal contribution for an eager array or bounded file
+  chunk.
+- Eager frames add the rendered contribution to `Frame.data`.
+- File-backed frames read a bounded NumPy chunk, render into that chunk, and
+  write it back immediately.
+- Both paths use the same renderer and therefore the same signal model.
+
+The renderer should accept an array module, not import CuPy directly:
+
+```python
+xp = get_array_module(backend)
+signal = render_signal_chunk(..., xp=xp, compute_dtype=...)
+```
+
+Built-in paths and profiles should be backend-aware where practical. They
+should use the provided array module instead of hard-coded `numpy` calls.
+
+Arbitrary user callables in GPU mode are a contract: they must either be
+backend-compatible or the user must request `backend="numpy"`. We should raise a
+clear error if a callable fails under CuPy rather than silently materializing
+large host arrays.
+
+## File-Backed Injection Policy
+
+File-backed GPU acceleration should preserve the current memory goal. It should
+never require loading the full observation into memory.
+
+For a writable file-backed frame, each affected chunk follows this pattern:
+
+1. compute the bounded time/frequency region affected by the signal
+2. read only that region as a NumPy array
+3. convert the chunk to the selected array backend
+4. render/add the signal contribution on that backend
+5. convert the patched chunk back to NumPy
+6. cast according to the storage dtype policy
+7. write the region and flush at the existing mutation boundary
+
+The GPU path saves memory in the same way as the CPU file-backed path: memory is
+bounded by chunk shape, not observation shape. GPU acceleration changes where
+the chunk math happens; it does not change the I/O contract.
+
+The first implementation should optimize correctness and API consistency over
+transfer cleverness. Later optimizations can reuse device buffers across chunks
+or tune chunk sizes, but those should be invisible to the public API.
+
+## Noise And SNR Policy
+
+`NoiseEstimationConfig` currently uses sigma clipping, which matches the
+existing frame behavior and the science preference for local windows around the
+injection. Keep that CPU-first for the initial backend work because Astropy
+sigma clipping and file-backed local reads already operate on modest host
+arrays.
+
+GPU signal rendering can still use CPU-estimated noise stats:
+
+```python
+stats = frame.estimate_noise_stats(path=path, config=config)
+frame.add_signal(..., snr=snr, noise_stats=stats, backend="cupy")
+```
+
+Future GPU noise estimation is allowed, but it should keep the same
+`NoiseStats` output and should not change SNR semantics.
+
+## Dtype Policy
+
+Default behavior should preserve current NumPy results as closely as practical.
+Do not silently downcast scientific products just because the GPU path exists.
+
+Add an explicit compute dtype later:
+
+```python
+SignalRenderConfig(compute_dtype=None)
+```
+
+where `None` means preserve current behavior. File-backed writes still cast to
+the storage dtype after rendering. If the storage dtype is integer or otherwise
+lossy, the write path should make that conversion explicit and tested.
+
+## Randomness Policy
+
+Backend-aware random generation should use the selected module's random
+implementation where appropriate. Exact bitwise equivalence between NumPy and
+CuPy should not be promised. Tests should compare shape, dtype, deterministic
+behavior within a backend, and statistical properties where relevant.
+
+For signal injection, deterministic paths/profiles should remain exactly
+comparable across CPU and GPU within reasonable floating-point tolerance.
+
+## Implementation Plan
+
+1. Create `setigen._array_backend` by moving the voltage helper to package
+   scope.
+2. Leave `setigen.voltage._array_backend` as a compatibility shim that reexports
+   the package helper.
+3. Reexport `set_backend()` and `get_backend()` from `setigen.__init__`.
+4. Update voltage imports to use the package helper or compatibility shim, but
+   ensure there is only one global backend state.
+5. Add package-level tests for backend validation, legacy environment fallback,
+   explicit CuPy errors, and `to_numpy(...)`.
+6. Split `Frame.add_signal()` rendering from mutation.
+7. Add `backend="auto"` to eager frame signal rendering.
+8. Add the same backend resolution to file-backed chunk mutation.
+9. Port built-in signal helper functions to backend-aware array operations.
+10. Add optional CuPy tests that skip cleanly when CuPy is unavailable.
+11. Update docs so voltage, frame, and file-backed injection examples describe
+    the same backend policy.
+
+## Validation Requirements
+
+- Existing voltage backend tests continue to pass.
+- `stg.set_backend(...)` and `stg.voltage.set_backend(...)` affect the same
+  state.
+- Explicit `backend="cupy"` raises a clear `ImportError` when CuPy is missing.
+- Legacy `SETIGEN_ENABLE_GPU=1` keeps the current auto fallback behavior.
+- CPU eager `Frame.add_signal()` remains numerically compatible with current
+  behavior.
+- CPU and GPU signal rendering match within floating-point tolerance on small
+  fixtures when CuPy is installed.
+- File-backed CPU and GPU injection produce equivalent patched regions on small
+  `.fil` and `.h5` fixtures.
+- Plotting after file-backed injection still shows the patched data because
+  plotting reads host chunks from the backing file.
+
+## Open Decisions
+
+- Should `Frame.add_signal(..., backend=...)` be added directly, or should
+  signal rendering get a config object first?
+- Should GPU user-callable failures always raise, or should we offer an
+  explicit `callable_backend="numpy"` escape hatch?
+- What default chunk size is best when CPU/GPU transfer overhead is included?
+- Do we need a public `stg.get_array_module()` for advanced users, or should the
+  array module remain internal until a clear use case appears?
+- Should `compute_dtype` default to current float behavior forever, or should
+  large GPU/file-backed workflows get an opt-in `float32` preset?

--- a/docs/plans/file_backed_spectrogram_injection.md
+++ b/docs/plans/file_backed_spectrogram_injection.md
@@ -1,0 +1,549 @@
+# File-Backed Spectrogram Injection Plan
+
+This plan tracks the proposed replacement for `blimpy`-centered waterfall I/O
+when injecting synthetic narrowband signals into large observational
+spectrograms. The goal is to keep the current `Frame` API usable while allowing
+read/write operations against many-GB `.fil` and `.h5` products without loading
+the full observation into memory.
+
+## Current Branch Context
+
+The branch `feature/20260426-overhaul-I/O-towards-efficient-injection` already
+moves `Frame` closer to this model:
+
+- `Frame` owns serializable observation context instead of live waterfall file
+  handles.
+- Loading a waterfall copies data and header metadata, then closes file handles
+  opened by `setigen`.
+- Derived frames preserve observation context deliberately, including start
+  time, source name, filterbank header, and user metadata.
+- Axis helpers expose frequency/time centers and edges so plotting, injection,
+  and drift-rate calculations can share one convention.
+
+The current helper surfaces are:
+
+- `setigen._frame.context._copy_frame_context()` for derived-frame metadata and
+  header propagation.
+- `setigen._frame.io` for waterfall adapter creation, serialization, and
+  header/data synchronization.
+- `setigen.voltage._reduction.frame_context._frame_context_kwargs()` for
+  carrying filterbank context from voltage reductions into `Frame.from_data()`.
+
+These were useful groundwork for the file-backed implementation slice below.
+
+## Implemented Slice
+
+The first implementation slice now exists on this branch:
+
+- `Frame.open(path, mode="r")` opens `.h5`, `.hdf5`, and `.fil` products as
+  read-only file-backed frames.
+- `Frame.open(path, mode="r+", allow_inplace=True)` enables explicit direct
+  mutation of an existing file.
+- `Frame.open_copy(input_path, output_path)` copies the input file on disk and
+  opens the copy as a writable file-backed frame. This is the preferred safe
+  mutation path.
+- File-backed frames are context managers and close their HDF5/raw file handles
+  on exit.
+- `Frame.read_frame(...)` reads a bounded region into a normal eager `Frame`.
+  It accepts physical `f_range`/`t_range` or half-open
+  `f_index_range`/`t_index_range`.
+- `Frame.add_signal(...)` on a writable file-backed frame patches the backing
+  file immediately in time chunks. It returns a `FileBackedSignalResult`
+  summary instead of a full signal array, because returning a full array would
+  defeat the memory-savings goal.
+- `Frame.plot(...)` accepts the same region arguments and reads plotted
+  file-backed data from the current backing store, so plots after injection show
+  the patched signal.
+- `NoiseEstimationConfig` and `NoiseStats` provide a shared sigma-clipping
+  noise-stat path. Eager frames keep their existing full-frame behavior, while
+  file-backed frames can estimate stats from explicit local context windows.
+- `Frame.get_intensity(..., noise_stats=...)` and
+  `Frame.get_snr(..., noise_stats=...)` can use explicit stats without changing
+  legacy calls that rely on cached frame noise.
+
+The implemented private modules are:
+
+- `setigen._spectrogram.base`
+- `setigen._spectrogram.h5`
+- `setigen._spectrogram.fil`
+- `setigen._frame.file_mutation`
+- `setigen.noise`
+
+Current limitations:
+
+- File-backed synthetic noise mutation is intentionally not implemented. It
+  would require broad full-file mutation, not narrowband chunk patching.
+- `open_copy()` performs a full file copy up front. It is memory-bounded but
+  still pays full-file disk I/O.
+- SNR-based file-backed injection remains future work, but local file-backed
+  noise-stat estimation is available for explicit contexts.
+- File-backed `add_signal()` evaluates callable time/path profiles over the
+  full time axis first so chunked rendering stays consistent across chunks.
+  This is much smaller than loading the full spectrogram, but it is still an
+  O(`tchans`) allocation.
+
+## Goals
+
+- Support `.fil` and `.h5` observations whose full spectrogram arrays are too
+  large to fit comfortably in memory.
+- Preserve the existing eager in-memory behavior:
+
+  ```python
+  frame = stg.Frame(waterfall="obs.h5")
+  frame.add_signal(...)
+  frame.save_hdf5("obs_injected.h5")
+  ```
+
+- Add an explicit file-backed API that still feels like `Frame`.
+- Make mutating methods write immediately when called. There should be no lazy
+  pending-injection plan that only materializes during a later save.
+- Make copy-backed mutation the default safe path for real observations.
+- Allow direct in-place mutation only through an explicit power-user API.
+- Ensure `frame.plot()` after `frame.add_signal()` reads the patched backing
+  file and shows the injected signal.
+
+## Non-Goals
+
+- Do not preserve `blimpy.Waterfall` as the internal abstraction for new
+  file-backed writes.
+- Do not hide large-file behavior behind sentinel arrays or partially loaded
+  `.data` objects.
+- Do not make SNR-based injection silently scan full multi-GB products unless
+  the caller explicitly asks for that cost.
+- Do not mutate original observational products by default.
+
+## Blimpy Audit
+
+`blimpy.Waterfall` is a facade over `.fil` and `.h5` readers. It parses headers,
+normalizes selection ranges, optionally materializes data into `Waterfall.data`,
+and exposes plotting plus format conversion helpers.
+
+Useful behavior to keep:
+
+- `.fil` reading computes the SIGPROC header length, converts a frequency range
+  to channel indices, seeks row-by-row, and reads selected frequency spans.
+- `.h5` reading uses HDF5 dataset slicing for hyperslab reads.
+- Heavy-file conversion writes large products in blobs instead of materializing
+  the entire observation.
+
+Problems to avoid:
+
+- Reader, writer, plotting, selection state, memory policy, and data ownership
+  are mixed into one object.
+- Large-file state is implicit rather than represented by a clear file-backed
+  backend.
+- Resource ownership is implicit; HDF5 handles can live longer than expected.
+- Some writer failures use process exits, which is not acceptable library
+  behavior.
+- The public API is conversion-oriented, not injection-oriented. There is no
+  clean mutation-by-region API for patching an affected window and returning.
+
+## Proposed API
+
+Existing eager behavior remains valid:
+
+```python
+frame = stg.Frame(waterfall="obs.h5")
+frame.add_signal(...)
+frame.save_hdf5("obs_injected.h5")
+```
+
+Read-only file-backed access:
+
+```python
+with stg.Frame.open("obs.fil", mode="r") as frame:
+    small = frame.read_frame(f_range=(6000.0, 6000.1), t_range=(0, 32))
+    frame.plot(f_range=(6000.0, 6000.1), t_range=(0, 128))
+```
+
+Safe writable copy-backed access:
+
+```python
+with stg.Frame.open_copy("obs.h5", "obs_injected.h5") as frame:
+    frame.add_signal(..., auto_bounding=True, truncate_below=1e-3)
+    frame.plot(f_range=(6000.0, 6000.1), t_range=(0, 128))
+```
+
+Explicit direct mutation:
+
+```python
+with stg.Frame.open("obs_copy.h5", mode="r+", allow_inplace=True) as frame:
+    frame.add_signal(...)
+```
+
+`Frame.open_copy()` should be the preferred API for real observations. Phase 1
+can copy the full file up front, which is disk-I/O heavy but memory-bounded.
+Later phases can optimize this with staged sparse or region-copy strategies
+where the file format makes that safe.
+
+## Object Model
+
+`Frame` should be backed by a small internal backend interface:
+
+- `InMemoryFrameBackend`: owns a normal NumPy array and supports the existing
+  implementation path.
+- `FileFrameBackend`: owns a context-managed file backend, exposes metadata and
+  region reads, and optionally exposes region writes.
+
+Candidate private modules:
+
+- `setigen._spectrogram.base`: shared metadata model, selection normalization,
+  axis conversions, and the `SpectrogramBackend` protocol.
+- `setigen._spectrogram.fil`: native SIGPROC `.fil` parser, row/region reader,
+  staged writer, and optional `np.memmap` support for safe contiguous cases.
+- `setigen._spectrogram.h5`: native HDF5 reader/writer using `h5py` datasets and
+  hyperslab selection.
+- `setigen._frame.backends`: in-memory and file-backed frame backend adapters.
+- `setigen._frame.streaming_signal`: chunked signal rendering and immediate
+  patch application.
+- `setigen._frame.file_mutation`: copy guards, writable-region patching, and
+  injection metadata bookkeeping.
+
+The backend boundary should be private. Public users should still think in
+terms of `Frame`.
+
+## Mutable Write Semantics
+
+A file-backed frame has either a read-only backend or a writable backend.
+
+- `Frame.open(path, mode="r")` opens metadata and region readers only.
+  `read_frame()` and `plot()` work, but `add_signal()` raises.
+- `Frame.open_copy(input_path, output_path)` creates a writable product from
+  the input observation. Mutating methods patch that writable product
+  immediately.
+- `Frame.open(path, mode="r+", allow_inplace=True)` opens an existing product
+  for direct mutation. This should remain explicit because it can corrupt or
+  alter original observational data.
+- `add_signal()` on a writable file-backed frame resolves the affected region,
+  processes that region in memory-bounded chunks, writes each patched chunk back
+  before returning, and records injection metadata in memory and, where
+  possible, in output metadata.
+- `plot()` after `add_signal()` reads from the already-patched backing file.
+  The plot should show the signal without a separate save step.
+
+The important distinction is that the copy operation and the mutation operation
+are separate safety concepts. `open_copy()` protects observational input.
+Chunked mutation protects memory usage.
+
+## Immediate Chunked Injection Algorithm
+
+When `add_signal()` is called on a writable file-backed frame:
+
+1. Validate that the backend is writable.
+2. Resolve the injection's affected frequency range from explicit
+   `bounding_f_range` or the existing `auto_bounding` machinery. If no safe
+   range can be inferred, fall back to the full frequency span while still
+   chunking over time.
+3. Convert the affected frequency range into channel indices, respecting
+   negative `foff` and ascending/descending channel order.
+4. Choose a chunk shape from a memory budget, dtype, and file layout. Phase 1
+   can process time-contiguous chunks across the affected frequency span.
+5. For each chunk, read only `time[t0:t1]` and `freq[f0:f1]` from the backing
+   file into a NumPy array.
+6. Build a lightweight frame-like view for that chunk with correct `df`, `dt`,
+   `fch1`, `ascending`, `t_start`, and `t_offset`.
+7. Render the same signal profile that eager `Frame.add_signal()` would render,
+   but only for this chunk's time/frequency window.
+8. Add the rendered signal into the chunk array.
+9. Write that chunk back to the same region of the writable backing file before
+   moving to the next chunk.
+10. Flush the backend and update injection metadata before `add_signal()`
+    returns.
+
+This makes the function call itself the point of mutation. There is no delayed
+render/save stage.
+
+## Why This Saves Memory
+
+The eager path needs memory proportional to the selected observation:
+
+```text
+memory ~= n_times * n_chans * bytes_per_sample
+```
+
+The file-backed path needs memory proportional to the active chunk:
+
+```text
+memory ~= chunk_n_times * affected_n_chans * bytes_per_sample
+```
+
+For a narrowband injection, `affected_n_chans` can be a tiny fraction of the
+full observation. A 24-hour product with millions of channels may be tens or
+hundreds of GB, but a signal that occupies a few thousand channels can be
+patched in chunks that are tens or hundreds of MB.
+
+This also limits compute to the affected region. The signal renderer does not
+need to evaluate profiles across the full spectrogram when the bounding region
+is known.
+
+`open_copy()` may still perform a full-file disk copy in phase 1. That is an
+I/O cost, not a memory cost. The copy protects the original file; the chunked
+patching protects memory.
+
+## Backend Write Details
+
+HDF5 writes should use dataset hyperslabs:
+
+```python
+dataset[t0:t1, if_id, f0:f1] = patched_chunk
+```
+
+The actual dimension order should be normalized behind the HDF5 backend so
+`Frame` code does not know whether the on-disk data are shaped as
+`(time, if, frequency)` or something backend-specific.
+
+Filterbank writes are row-window overwrites. For a single IF and row-major
+SIGPROC layout, the byte offset for a row window is:
+
+```text
+offset = header_size + ((time_index * nifs + if_id) * nchans + f0) * bytes_per_sample
+```
+
+Then the backend seeks to `offset` and writes `f1 - f0` samples for that time
+row. Multi-IF products and frequency orientation should be handled inside the
+backend.
+
+Both backends need:
+
+- metadata-only open
+- context-manager close behavior
+- region read
+- optional region write
+- explicit flush
+- errors instead of process exits
+
+## Plot Compatibility
+
+Plotting should not require a separate API. For a file-backed frame,
+`Frame.plot()` can request the displayed time/frequency window from
+`FileFrameBackend.read_region()` and then use the same plotting code path as an
+eager frame.
+
+That means:
+
+- read-only file-backed plots show current on-disk data
+- writable file-backed plots show patched data after `add_signal()`
+- very large plots should require an explicit visible region or downsampling
+  strategy rather than accidentally loading an entire observation
+
+## Noise and SNR Policy
+
+Explicit signal `level` can work immediately for file-backed injection.
+
+`get_intensity(snr=...)` currently depends on `Frame.noise_std`, which assumes
+materialized data. File-backed frames need an explicit estimator before
+SNR-based injection is reliable:
+
+```python
+stats = frame.estimate_noise_stats(
+    path=stg.constant_path(...),
+    f_profile=stg.box_f_profile(...),
+    t_range=(0, 1024),
+    config=stg.NoiseEstimationConfig(
+        context_width=2048,
+        guard_width=64,
+    ),
+)
+```
+
+Exact full-file sigma clipping should not be the default for GB-scale files, and
+it is not scientifically right for many BL-style products. PFB scalloping and
+coarse-channel bandpass structure mean the local baseline and variance can
+change across frequency. A global mean/std can overstate or understate the
+true local SNR depending on where the injected signal lands in the spectral
+response.
+
+The first SNR implementation should use local context windows:
+
+- Resolve the signal path and its affected channels using the same bounding
+  machinery used for injection.
+- For each time chunk, read a surrounding frequency window around the signal
+  path, not the full observation.
+- Exclude the signal-support region plus a guard band before estimating noise.
+  This matters both before injection and after injection if users ask to inspect
+  achieved SNR.
+- Estimate background with local sigma clipping by default, matching the
+  existing `Frame._update_noise_frame_stats()` convention. The initial defaults
+  should stay consistent with the current eager path: `sigma=3`, `maxiters=5`,
+  and unmasked output before computing mean/std.
+- Keep median/MAD as an alternate robust estimator, but do not make it the
+  default unless we intentionally decide to change setigen's broader noise
+  convention.
+- Allow users to choose the context scale in channels or Hz. The default should
+  be wide enough to sample nearby bandpass/scalloping behavior but narrow enough
+  not to cross unrelated coarse-channel structure unnecessarily.
+- Return structured metadata: local mean, local std, number of samples, context
+  bounds, excluded bounds, method, and whether the estimate was sampled or
+  exhaustive.
+
+Candidate API:
+
+```python
+config = stg.NoiseEstimationConfig(
+    method="sigma_clip",
+    sigma=3,
+    maxiters=5,
+    context_width=2048,
+    guard_width=64,
+    width_unit="channels",
+)
+
+stats = frame.estimate_noise_stats(
+    path=path,
+    bounding_f_range=None,
+    auto_bounding=True,
+    t_range=(0, 1024),
+    config=config,
+)
+
+level = frame.get_intensity(snr=25, noise_stats=stats)
+```
+
+The config object should be a small typed public spec, probably a dataclass or
+frozen model, rather than a loose dictionary. That gives us stable defaults,
+validation, serialization into injection metadata, and an obvious extension
+point for later response-aware estimation. A possible shape:
+
+```python
+@dataclass(frozen=True)
+class NoiseEstimationConfig:
+    method: str = "sigma_clip"
+    sigma: float = 3
+    maxiters: int = 5
+    context_width: int | float = 2048
+    guard_width: int | float = 64
+    width_unit: str = "channels"
+    combine: str = "pooled"
+```
+
+`combine="pooled"` would compute one effective mean/std from all accepted local
+samples. Later options might preserve per-chunk statistics or weight chunks by
+the expected spectral response.
+
+The estimator should mirror `Frame` semantics without freezing current `Frame`
+internals as perfect. The public meaning of `get_noise_stats()`,
+`get_intensity(snr=...)`, and `get_snr(...)` should stay stable, while the
+shared implementation becomes more explicit and better documented. Eager
+`Frame` should keep full-frame sigma clipping as its default for backward
+compatibility. File-backed frames should use the same estimator over local
+context windows when SNR is requested for an injection path.
+
+For file-backed `add_signal(snr=...)` support, avoid implicit full-file
+estimation. Require either caller-supplied `noise_stats` or enough local-window
+configuration to make the estimator explicit and reproducible.
+
+Longer term, `estimate_noise_stats()` can support a path-local mode that walks
+the signal path in chunks, estimates a local baseline per time/frequency
+neighborhood, and combines those local estimates into one effective intensity
+scale for the requested injection.
+
+## Spectral Response Localization
+
+A separate but related analysis goal is to infer where a file appears to sit in
+the instrumental spectral response. We usually know where the PFB/coarse-channel
+response should be, but real products may have slight offsets or calibration
+imperfections.
+
+This should be treated as analysis metadata, not a prerequisite for the first
+file-backed injection implementation. Possible long-term approach:
+
+- Estimate a smooth or periodic bandpass response over local frequency windows.
+- Compare measured response shape against expected PFB/coarse-channel response.
+- Fit a small phase/offset parameter indicating where fine channels appear to
+  lie in the scalloping pattern.
+- Cache that response model on the file-backed frame and expose it to SNR
+  estimation so local noise windows can be interpreted in instrumental context.
+- Keep this opt-in and inspectable; do not silently correct injected amplitudes
+  using an inferred response model until the science assumptions are validated.
+
+This could eventually support APIs such as:
+
+```python
+response = frame.estimate_spectral_response(
+    f_range=(...),
+    t_range=(...),
+    model="pfb_scalloping",
+)
+
+stats = frame.estimate_noise_stats(path=path, response_model=response)
+```
+
+## Frame Improvement Roadmap
+
+The file-backed work exposes a few `Frame` improvements that are useful even
+without large files:
+
+1. Done: extract the current sigma-clipped noise calculation into a shared
+   `NoiseEstimationConfig` / `NoiseStats` implementation. This keeps eager
+   behavior compatible while making the science assumptions explicit.
+2. Split signal rendering from mutation. `Frame.add_signal()` currently renders
+   and mutates in one method. A reusable chunk renderer would let eager,
+   file-backed, and GPU paths share exactly the same signal model.
+3. Add optional CuPy acceleration after the renderer split. CuPy should be an
+   optional backend, not a hard dependency. The file-backed path can read a
+   NumPy chunk, transfer it to GPU, render and add the signal, transfer the
+   patched chunk back, and write it. The package-wide policy for this lives in
+   `docs/plans/array_backend_acceleration.md`.
+4. Make built-in paths and profiles backend-aware where practical. User
+   callables in GPU mode may need to be CuPy-compatible or explicitly fall back
+   to CPU rendering.
+5. Add a clear dtype policy for rendering and writing. Compute dtype and output
+   dtype should be explicit, especially for HDF5/FIL products.
+6. Add injection metadata/history including signal parameters, noise config and
+   stats, chunking, and CPU/GPU backend.
+7. Revisit `frame.data` for file-backed frames. It currently materializes the
+   full file for compatibility, but long-term large-file workflows should prefer
+   explicit `read_frame()` or `materialize()` calls with size guards.
+
+## Implementation Phases
+
+1. Done: build read-only metadata and region readers for `.fil` and `.h5`, with
+   context-manager ownership and tests against `blimpy` on small fixtures.
+2. Done: add `Frame.open()` and `read_frame()` so users can choose eager or lazy
+   behavior explicitly.
+3. Done: add writable region backends and `Frame.open_copy()`. Start with
+   full-file copy creation because it is simple, safe, and memory-bounded.
+4. Done: make file-backed `add_signal()` patch writable chunks immediately and make
+   `plot()` read back from the patched file.
+5. Next: optimize narrowband injections by copying or reading unaffected spans
+   directly instead of materializing entire rows or full time blocks.
+6. Partly done: add local-window file-backed noise-stat estimation and SNR
+   conveniences. Explicit stats are available; direct `add_signal(snr=...)`
+   integration remains next.
+7. Later: consider staged sparse output strategies after correctness and resource
+   ownership are solid.
+8. Later: add opt-in spectral-response localization for PFB scalloping and
+   calibration-offset analysis.
+9. Later: split signal rendering from mutation and add optional CuPy
+   acceleration on top of the shared renderer. The acceleration work should
+   follow the shared array backend spec in
+   `docs/plans/array_backend_acceleration.md`.
+
+## Validation Requirements
+
+- Small `.fil` and `.h5` fixtures must produce value-equivalent output to eager
+  `Frame` injection.
+- Tests must assert memory stays bounded by configured chunk size.
+- HDF5 file handles and raw file handles must close after normal and
+  exceptional exits.
+- Negative `foff`, ascending frequency products, `nifs`, and time/frequency
+  sub-selections need direct coverage.
+- Read-only file-backed `add_signal()` must raise a clear error.
+- Copy-backed mutation must not alter the input path.
+- Direct in-place update, if added, must be opt-in and separately tested.
+
+## Open Decisions
+
+- Should the public constructor be `Frame.open(...)`, `stg.open_frame(...)`, or
+  both?
+- Should direct mutation require both `mode="r+"` and `allow_inplace=True`, or
+  is one explicit flag enough?
+- What should the default memory budget be for chunked injection?
+- What local context width and guard width should be the default for SNR
+  estimation, and should widths be specified in channels, Hz, or both?
+- Should local noise stats be summarized into one effective SNR scale, or should
+  we preserve per-chunk/per-path statistics for downstream analysis?
+- Should plotting an unbounded large file-backed frame raise, downsample, or ask
+  for an explicit range?
+- What injection metadata should be written into HDF5 attrs or filterbank
+  headers versus kept only in the Python object?

--- a/docs/plans/frame_derived_products.md
+++ b/docs/plans/frame_derived_products.md
@@ -1,0 +1,272 @@
+# Frame Derived Product Plan
+
+This plan tracks the `Frame`, `Spectrum`, `TimeSeries`, and helper cleanup that
+should happen alongside file-backed injection. These products are common
+scientific operations, so they should have clear semantics, consistent metadata,
+and memory-bounded behavior on large observations.
+
+## Current State
+
+The current branch has moved `Frame` in the right direction:
+
+- Frame construction is split into `setigen._frame.construction`.
+- Waterfall/header synchronization is split into `setigen._frame.io`.
+- Signal rendering helpers live in `setigen._frame.signal`.
+- File-backed mutation lives in `setigen._frame.file_mutation`.
+- File-backed spectrogram readers live in `setigen._spectrogram`.
+- Noise statistics now share `NoiseEstimationConfig` and `NoiseStats`.
+- `slice`, `dedrift`, `read_frame`, and `integrate` use
+  `_finalize_derived_frame()` so derived frames preserve source name, start
+  time, headers, custom metadata, and operation provenance.
+- Plot axis logic is centralized in `setigen._plot.axes`.
+- Done: `Spectrum` and `TimeSeries` accept one-dimensional data and coerce it
+  into the singleton-axis frame representation.
+- Done: `read_frame`, `slice`, `dedrift`, `spectrum`, and `timeseries` attach
+  explicit `metadata["derived"]` payloads and synchronize derived headers.
+- Done: `spectrum()` and `timeseries()` support region selectors and chunked
+  file-backed `mean` / `sum` reductions.
+
+This is good groundwork. `Frame` is still doing too much, but the newly added
+helpers are now strong enough to support incremental cleanup instead of a large
+rewrite.
+
+## Spectrum And TimeSeries Semantics
+
+The current representation mostly makes sense:
+
+- A `Spectrum` is a one-row `Frame` with shape `(1, fchans)`.
+- A `TimeSeries` is a one-channel `Frame` with shape `(tchans, 1)`.
+- `spectrum(frame, mode="mean" | "sum")` integrates over time.
+- `timeseries(frame, mode="mean" | "sum")` integrates over frequency.
+
+This model is worth keeping because it reuses existing axis, plotting, I/O, and
+metadata behavior. The singleton-axis convention also serializes naturally into
+filterbank/HDF5-style products.
+
+The physical parameter interpretation should be explicit:
+
+- `Spectrum.df` remains the source channel width.
+- `Spectrum.dt` becomes the collapsed time span represented by the spectrum.
+- `Spectrum.fch1` follows the selected frequency span.
+- `Spectrum.t_start` remains the start time of the selected time span.
+- `TimeSeries.dt` remains the source time resolution.
+- `TimeSeries.df` becomes the collapsed frequency bandwidth.
+- `TimeSeries.fch1` should be the center frequency of the collapsed frequency
+  span, so its single channel has meaningful edges at
+  `fch1 +/- df / 2`.
+- `TimeSeries.t_start` follows the selected time span.
+
+## Problems To Fix
+
+1. Derived-product provenance is under-specified.
+
+   `Spectrum` and `TimeSeries` currently inherit custom metadata, but they do
+   not record that they were produced by integrating a source frame, which axis
+   was collapsed, what reducer was used, what region was selected, or whether
+   normalization was applied.
+
+2. Header propagation is too literal.
+
+   `_copy_frame_context()` copies `frame.header`, while the derived frame's
+   core dimensions live separately in `fchans`, `tchans`, `df`, `dt`, and
+   `fch1`. Save paths rebuild headers from the frame object, so serialization is
+   mostly protected, but the in-memory `header` attribute can be stale after
+   `slice`, `dedrift`, or `integrate`.
+
+3. Done: `integrate()` used to materialize file-backed frames.
+
+   `spectrum()` and `timeseries()` now reduce file-backed frames in chunks for
+   `mean` and `sum`. Reducers beyond those still need explicit memory policy.
+
+4. The reduction spec is too small.
+
+   `IntegrationMode` currently supports `mean` and `sum`. Those are the right
+   initial reducers, but common frame products also need a consistent place for
+   selected time/frequency ranges, normalization policy, local noise settings,
+   and future reducers.
+
+5. Normalization vocabulary is inconsistent.
+
+   `integrate(normalize=True)` applies sigma-clipped zero-mean/unit-variance
+   normalization to the reduced output. `Spectrum.plot(snr=True)` does a
+   sigma-normalized copy. `TimeSeries.plot(norm=True)` divides by the mean.
+   These are all useful, but they should not share one vague word.
+
+6. Direct `Spectrum` and `TimeSeries` constructors are not friendly to common
+   one-dimensional inputs.
+
+   The classes internally store singleton-axis 2D arrays, but direct users
+   should be able to pass a 1D spectrum or time series and get the expected
+   shape. Constructor guards should raise `ValueError`, not `assert`.
+
+## Shared Collapse Spec
+
+Add a shared collapse/reduction spec and route `integrate()`, `spectrum()`, and
+`timeseries()` through it.
+
+Candidate public surface:
+
+```python
+frame.spectrum(
+    reducer="mean",
+    normalize=None,
+    f_range=None,
+    t_range=None,
+    f_index_range=None,
+    t_index_range=None,
+    noise_config=None,
+    max_chunk_bytes=None,
+)
+
+frame.timeseries(
+    reducer="mean",
+    normalize=None,
+    f_range=None,
+    t_range=None,
+    f_index_range=None,
+    t_index_range=None,
+    noise_config=None,
+    max_chunk_bytes=None,
+)
+```
+
+The existing top-level functions should remain:
+
+```python
+stg.spectrum(frame, mode="mean")
+stg.timeseries(frame, mode="mean")
+stg.integrate(frame, axis="time", mode="mean")
+```
+
+but internally they should normalize into a shared spec.
+
+Initial reducer support:
+
+- `mean`
+- `sum`
+
+Future reducer support can include `median`, `std`, `max`, and percentile-like
+reducers, but only after we decide how to handle them in chunked file-backed
+mode.
+
+Initial normalization support:
+
+- `None` or `"none"`: return physical integrated power.
+- `"sigma_clip"`: use `NoiseEstimationConfig` on the reduced product.
+- `"mean"`: divide by the reduced-product mean.
+
+Avoid a bare `normalize=True` in new APIs. Keep it as a compatibility alias
+where it already exists.
+
+## Derived Metadata
+
+Derived products should carry source context and explicit operation metadata.
+Use plain Python primitives so metadata remains serializable.
+
+Candidate structure:
+
+```python
+metadata["derived"] = {
+    "operation": "integrate",
+    "product_type": "spectrum",
+    "collapsed_axis": "time",
+    "reducer": "mean",
+    "normalization": None,
+    "source_shape": (tchans, fchans),
+    "source_bounds": {
+        "time_index_range": (t_start, t_stop),
+        "frequency_index_range": (f_start, f_stop),
+        "time_range_s": (time_start_s, time_stop_s),
+        "frequency_range_hz": (f_min_hz, f_max_hz),
+    },
+}
+```
+
+For `TimeSeries`, use:
+
+```python
+metadata["derived"] = {
+    "operation": "integrate",
+    "product_type": "timeseries",
+    "collapsed_axis": "frequency",
+    ...
+}
+```
+
+If normalization uses noise statistics, add:
+
+```python
+metadata["derived"]["noise_stats"] = noise_stats_metadata
+metadata["derived"]["noise_config"] = noise_config_metadata
+```
+
+For `slice` and `dedrift`, use the same `derived` key with operation-specific
+payloads instead of only copying free-form metadata.
+
+## Header Policy
+
+Create a helper that copies source context and updates frame-specific header
+fields after a derived product is created.
+
+Candidate private helper:
+
+```python
+_finalize_derived_frame(
+    source,
+    target,
+    *,
+    operation,
+    product_type=None,
+    source_bounds=None,
+    reducer=None,
+    normalization=None,
+)
+```
+
+It should:
+
+- deep-copy non-core custom metadata from the source
+- attach `metadata["derived"]`
+- deep-copy the source header when present
+- update header fields that must reflect the target frame:
+  `source_name`, `tsamp`, `tstart`, `nchans`, `nifs`, `fch1`, and `foff`
+
+This should replace direct `_copy_frame_context()` calls over time.
+
+## File-Backed Reduction
+
+`spectrum()` and `timeseries()` should be memory-bounded for file-backed frames.
+
+For `Spectrum`:
+
+- select the requested frequency/time region
+- read time chunks
+- accumulate sum and count per frequency channel
+- return sum or mean without loading the full observation
+
+For `TimeSeries`:
+
+- select the requested frequency/time region
+- read time chunks and, if needed, frequency chunks
+- reduce each time row across selected frequency channels
+- return sum or mean without loading the full observation
+
+This first file-backed implementation should support `mean` and `sum`. Reducers
+such as `median` need either larger memory, temporary storage, or approximate
+streaming algorithms and should be added deliberately.
+
+## Implementation Order
+
+1. Done: add constructor coercion for 1D `Spectrum` and `TimeSeries` inputs, replacing
+   singleton-axis `assert` checks with `ValueError`.
+2. Done: add a shared derived-frame finalizer that updates metadata and headers.
+3. Done: route `slice`, `dedrift`, `read_frame`, `spectrum`, and `timeseries` through
+   the finalizer.
+4. Done: add operation metadata tests for spectrum, timeseries, slicing, and dedrift.
+5. Done: add region-aware spectrum/timeseries APIs using the existing
+   `f_range`/`t_range` and index-range conventions.
+6. Done: add file-backed chunked `mean`/`sum` reductions.
+7. Revisit normalization names and preserve current booleans as compatibility
+   aliases.
+8. Add docs examples showing eager and file-backed spectrum/timeseries
+   workflows.

--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -308,6 +308,55 @@ To do this, we can use :func:`~setigen.sample_from_obs.get_parameter_distributio
 This will iterate over an entire filterbank file, estimating the noise statistics
 and returning them as numpy arrays.
 
+Local noise statistics for SNR
+------------------------------
+
+For signal injection into real observations, the most useful SNR reference is
+often local in frequency, not global across the whole observation. Coarse-channel
+structure, bandpass variation, and PFB scalloping can change the apparent noise
+level across the band. :class:`setigen.NoiseEstimationConfig` makes that choice
+explicit:
+
+.. code-block:: Python
+
+    config = stg.NoiseEstimationConfig(
+        method="sigma_clip",
+        sigma=3,
+        maxiters=5,
+        context_width=2048,
+        guard_width=64,
+        width_unit="channels",
+    )
+
+    stats = frame.estimate_noise_stats(
+        path=stg.constant_path(f_start=frame.get_frequency(512),
+                               drift_rate=2*u.Hz/u.s),
+        f_profile=stg.gaussian_f_profile(width=40*u.Hz),
+        auto_bounding=True,
+        truncate_below=1e-3,
+        config=config,
+    )
+
+    level = frame.get_intensity(snr=20, noise_stats=stats)
+
+The context window provides nearby samples for the estimate. The guard window
+excludes the signal neighborhood so the injected signal does not define its own
+noise. Sigma clipping is the default because it is consistent with existing
+frame noise behavior while rejecting bright outliers.
+
+For thin narrowband signals, keep signal rendering bounds and noise-estimation
+context separate. The signal may only need a small number of channels for
+mutation, while SNR calibration should use a wider local context with an
+excluded guard region. This gives the estimator enough samples to reject
+pre-existing narrowband contamination and to follow local bandpass/PFB response
+better than a global observation-wide statistic. The current file-backed
+implementation uses a rectangular local context for efficient contiguous reads;
+see :doc:`file_backed_frames` for the chunking and noise-context details.
+
+For file-backed observations, explicit local ranges are required so noise
+estimation does not accidentally scan a full many-GB product. See
+:doc:`file_backed_frames` for examples.
+
 
 Creating an injected synthetic signal dataset using observations
 ----------------------------------------------------------------

--- a/docs/source/array_backends.rst
+++ b/docs/source/array_backends.rst
@@ -1,0 +1,117 @@
+.. |setigen| replace:: :mod:`setigen`
+
+Array backend policy
+====================
+
+|setigen| uses NumPy arrays as the default numerical representation. The
+``setigen.voltage`` module also supports optional CuPy acceleration for
+array-heavy voltage synthesis and reduction work. The backend policy is being
+standardized so future frame and file-backed signal rendering can use the same
+vocabulary.
+
+Vocabulary
+----------
+
+Use ``array backend`` for numerical compute backends:
+
+``numpy``
+    CPU NumPy arrays.
+
+``cupy``
+    GPU CuPy arrays.
+
+``auto``
+    Resolve through the configured default and the legacy environment policy.
+
+Use ``file backend`` or ``storage backend`` for HDF5, filterbank, GUPPI RAW, or
+other I/O layers. Keeping these names separate matters because a workflow may
+read from an HDF5 storage backend while rendering chunks with a NumPy or CuPy
+array backend.
+
+Current public API
+------------------
+
+CuPy support is currently public in ``setigen.voltage``:
+
+.. code-block:: python
+
+    import setigen as stg
+
+    stg.voltage.set_backend("cupy")
+    print(stg.voltage.get_backend())
+
+Use ``"numpy"`` to force CPU execution:
+
+.. code-block:: python
+
+    stg.voltage.set_backend("numpy")
+
+Use ``"auto"`` to return to the default resolution policy:
+
+.. code-block:: python
+
+    stg.voltage.set_backend("auto")
+
+The legacy environment variable is still supported:
+
+.. code-block:: bash
+
+    export SETIGEN_ENABLE_GPU=1
+
+Resolution semantics
+--------------------
+
+The intended semantics are:
+
+- ``backend="numpy"`` always uses NumPy.
+- ``backend="cupy"`` requires CuPy and raises an ``ImportError`` if CuPy is not
+  installed.
+- ``backend="auto"`` follows the configured default.
+- The legacy ``SETIGEN_ENABLE_GPU=1`` path may fall back to NumPy when CuPy is
+  unavailable.
+- Explicit ``"cupy"`` should not silently fall back to CPU.
+
+This behavior already exists for voltage helpers. Future package-wide frame
+acceleration should reuse the same meanings rather than introducing separate
+GPU flags.
+
+Host arrays at public boundaries
+--------------------------------
+
+Public data products should remain host NumPy arrays unless a specific API says
+otherwise:
+
+- ``Frame.data`` is NumPy.
+- ``Frame.read_frame(...).data`` is NumPy.
+- ``VoltageSpectrogramResult.data`` is NumPy.
+- File-backed reads and writes exchange NumPy arrays.
+- Plotting receives NumPy arrays.
+
+Internal compute kernels may use CuPy arrays, but file I/O, plotting, and
+public frame materialization should convert back to host arrays explicitly.
+
+Future file-backed GPU rendering
+--------------------------------
+
+The planned frame/file-backed GPU path should be chunk-based:
+
+1. Read a bounded NumPy chunk from the file.
+2. Transfer that chunk to the selected array backend.
+3. Render and add the synthetic signal contribution.
+4. Transfer the patched chunk back to NumPy.
+5. Write the chunk to the backing file.
+
+This preserves the large-file memory model. GPU acceleration changes where the
+math happens; it should not require loading the full observation.
+
+Best practices
+--------------
+
+- Configure the array backend before constructing voltage objects.
+- Treat CuPy as optional. Do not make it a required dependency for general
+  frame work.
+- Keep public arrays on the host unless the API clearly documents otherwise.
+- Avoid hidden global backend assumptions in user callables. If a callable must
+  run on the GPU, make sure it is compatible with CuPy array operations.
+- Do not use ``auto`` as a performance heuristic. If tiny chunks should stay on
+  CPU in the future, that should be a separate explicit policy.

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -44,33 +44,32 @@ If you have a 2D Numpy array of spectrogram data, you may alternatively use
                                 dt=18.253611008*u.s,
                                 fch1=6095.214842353016*u.MHz,
                                 ascending=False,
-                                data)
+                                data=data)
                       
-If you know the parameters behind the data generation, and not necessarily the 
-actual frame resolution, you may use :func:`setigen.frame.Frame.from_backend_params`:
+If you know the backend parameters behind the data generation, you can derive
+the common frame-axis values and expand them into standard ``Frame`` creation.
+This keeps the backend-derived values explicit while leaving ``fch1`` attached
+to the slice or frequency reference you are actually using:
 
 .. code-block:: Python
 
-    frame = stg.Frame.from_backend_params(fchans=1024,
-                                          obs_length=300,
-                                          sample_rate=3e9,
-                                          num_branches=1024,
-                                          fftlength=1048576,
-                                          int_factor=51,
-                                          fch1=6*u.GHz,
-                                          ascending=False,
-                                          data=None)
+    frame_params = stg.frame_params_from_backend(obs_length=300,
+                                                 sample_rate=3e9,
+                                                 num_branches=1024,
+                                                 fftlength=1048576,
+                                                 int_factor=51)
+
+    frame = stg.Frame(fchans=1024,
+                      fch1=6*u.GHz,
+                      ascending=False,
+                      **frame_params)
                                           
-where ``obs_length`` is the integration period, ``sample_rate`` is the 
-sampling rate in Hz, code:`num_branches` is the branches in the polyphase 
-filterbank, code:`fftlength` is the number of fine channels per coarse channel, 
+where ``obs_length`` is the integration period, ``sample_rate`` is the
+sampling rate in Hz, ``num_branches`` is the branches in the polyphase
+filterbank, ``fftlength`` is the number of fine channels per coarse channel,
 and ``int_factor`` is the integration factor used in data reduction. Note 
 that ``int_factor`` is set to determine the number of time bins in the 
-frame. You may also set the ``data`` parameter to include existing 2D data, 
-from which ``fchans`` will be automatically inferred. Since multiple 
-``int_factor`` values may correspond to the same number of time bins, for 
-clarity we do not also infer ``int_factor`` just from the dimensions of the 
-data.
+frame.
 
 Finally, you can construct a frame directly from a ``.fil``/``.h5`` file or Waterfall object:
 
@@ -87,6 +86,11 @@ Alternately:
     
     frame_wf = stg.Frame.from_waterfall(wf)
     frame_path = stg.Frame.from_waterfall(wf_path)
+
+This constructor eagerly loads the selected data into memory. For many-GB
+observations, prefer the file-backed APIs documented in
+:doc:`file_backed_frames`, especially ``Frame.open()`` for inspection and
+``Frame.open_copy()`` for safe writable injection.
     
     
 Adding a basic signal

--- a/docs/source/file_backed_frames.rst
+++ b/docs/source/file_backed_frames.rst
@@ -1,0 +1,298 @@
+.. |setigen| replace:: :mod:`setigen`
+
+File-backed frames
+==================
+
+Large observational spectrograms are often many GBs. Loading the full dynamic
+spectrum into memory just to inject a narrowband signal is wasteful, and for
+some observations it is not practical at all. File-backed frames provide a
+memory-bounded alternative while keeping the main :class:`setigen.Frame`
+interface.
+
+The important distinction is:
+
+``stg.Frame(waterfall=...)``
+    Eager loading. The selected waterfall data are copied into memory and file
+    handles opened by |setigen| are closed after loading.
+
+``stg.Frame.open(...)``
+    File-backed loading. Metadata are loaded immediately, but spectrogram data
+    are read from the backing file only when a method requests a region.
+
+Use eager frames for small synthetic products, unit tests, and workflows that
+need the whole array. Use file-backed frames for real observations where the
+full spectrogram is too large to materialize casually.
+
+Opening observations
+--------------------
+
+Read-only access is the safest way to inspect large files:
+
+.. code-block:: python
+
+    import setigen as stg
+
+    with stg.Frame.open("observation.h5", mode="r") as frame:
+        print(frame.shape)
+        print(frame.df, frame.dt)
+        small = frame.read_frame(f_index_range=(1000, 1200),
+                                 t_index_range=(0, 64))
+
+The returned ``small`` object is a normal eager :class:`setigen.Frame` containing
+only the requested region.
+
+The same range convention is used by ``read_frame()`` and ``plot()``:
+
+.. code-block:: python
+
+    with stg.Frame.open("observation.fil", mode="r") as frame:
+        frame.plot(f_range=(6095.0e6, 6095.1e6),
+                   t_range=(0, 300),
+                   db=True)
+
+Ranges are relative to the frame:
+
+- ``f_range`` is a physical frequency range in Hz or Astropy frequency units.
+- ``t_range`` is a relative time range in seconds or Astropy time units.
+- ``f_index_range`` and ``t_index_range`` are half-open index ranges.
+
+Safe mutation by copying
+------------------------
+
+The preferred way to inject into real observations is copy-backed mutation:
+
+.. code-block:: python
+
+    from astropy import units as u
+    import setigen as stg
+
+    with stg.Frame.open_copy("observation.h5",
+                             "observation_injected.h5",
+                             overwrite=True) as frame:
+        result = frame.add_signal(
+            path=stg.constant_path(f_start=6095.05e6,
+                                   drift_rate=1.5 * u.Hz / u.s),
+            t_profile=stg.constant_t_profile(level=10),
+            f_profile=stg.gaussian_f_profile(width=40 * u.Hz),
+            auto_bounding=True,
+            truncate_below=1e-3,
+        )
+        frame.plot(f_range=(6095.04e6, 6095.06e6),
+                   t_range=(0, 300))
+
+``Frame.open_copy()`` copies the input file on disk, opens the copy as writable,
+and leaves the original observation unchanged. Mutating methods patch the output
+file immediately; there is no deferred injection plan that only takes effect on
+save.
+
+Direct in-place mutation is available, but it is intentionally explicit:
+
+.. code-block:: python
+
+    with stg.Frame.open("working_copy.h5",
+                        mode="r+",
+                        allow_inplace=True) as frame:
+        frame.add_signal(...)
+
+Only use direct mutation on a file that is already safe to modify.
+
+Chunked signal injection
+------------------------
+
+For writable file-backed frames, :meth:`setigen.Frame.add_signal` processes the
+affected frequency region in time chunks:
+
+1. Resolve the frequency channels touched by the signal.
+2. Read a bounded time/frequency chunk from the backing file.
+3. Render the synthetic signal contribution for that chunk.
+4. Add the contribution to the chunk.
+5. Write the chunk back to the backing file before returning.
+
+This keeps memory bounded by the configured chunk size and affected frequency
+width, not by the full observation shape. The return value is a
+``FileBackedSignalResult`` summary rather than a full signal array, because
+returning a full signal array would defeat the purpose of file-backed injection.
+
+The time chunk is the number of time bins processed in one read-render-write
+step. You can set it directly with ``chunk_tchans``. Otherwise |setigen| chooses
+it from ``max_chunk_bytes`` and the affected frequency width:
+
+.. code-block:: python
+
+    result = frame.add_signal(...,
+                              auto_bounding=True,
+                              max_chunk_bytes=64 * 1024**2)
+
+The default memory budget is 256 MiB. Internally, |setigen| reserves space for
+the data chunk and the temporary arrays used during signal rendering, so the
+chosen time chunk is conservative. A narrow bounded signal can usually process
+many time bins per chunk; an unbounded injection over the full band may need
+small time chunks.
+
+Behind the scenes, file-backed injection follows the same signal model as eager
+injection, but applies it to a small frame-like chunk view:
+
+1. Resolve ``auto_bounding`` or ``bounding_f_range`` into a frequency slice.
+2. Evaluate callable path and time profiles once on the full time axis when
+   needed, preserving stochastic consistency across chunks.
+3. For each time chunk, read ``[t_start:t_stop, f_start:f_stop]`` from the
+   backing file.
+4. Render the signal on that chunk's local time/frequency axes using the shared
+   frame rendering helpers.
+5. Add the signal into the chunk data and write that region back immediately.
+6. Flush the backend and return ``FileBackedSignalResult`` with the patched
+   frequency slice, number of time chunks, and largest chunk shape.
+
+Use ``auto_bounding=True`` with built-in finite-width profiles where possible.
+For profiles with long tails, also provide a scientifically meaningful
+``truncate_below`` value:
+
+.. code-block:: python
+
+    frame.add_signal(...,
+                     auto_bounding=True,
+                     truncate_below=1e-3)
+
+If a custom profile has broad support, pass an explicit ``bounding_f_range`` so
+the renderer does not need to evaluate the entire band.
+
+Noise and SNR with local context
+--------------------------------
+
+For real observations, a global mean and standard deviation can be a poor SNR
+reference. Bandpass structure, coarse-channel response, and PFB scalloping can
+make the noise level vary across frequency. File-backed workflows therefore
+prefer explicit local noise estimation.
+
+Signal rendering bounds and noise-estimation context are separate concepts:
+
+``signal render bounds``
+    The smallest frequency region where injected signal power is non-negligible.
+    These bounds control which file-backed data are patched.
+
+``noise guard``
+    A region around the signal support that is excluded from the background
+    estimate. This keeps the target track, and nearby line-like contamination,
+    from defining its own noise level.
+
+``noise context``
+    A wider local region around the guarded signal support used to estimate the
+    background mean and standard deviation.
+
+This distinction matters for thin, low-drift narrowband signals. Such a signal
+may only require a few tens of channels for mutation, but it should usually use
+thousands of neighboring channels for SNR calibration. Tight render bounds save
+I/O; wide local context gives a statistically useful background estimate.
+
+Use :class:`setigen.NoiseEstimationConfig` to describe the local context:
+
+.. code-block:: python
+
+    from astropy import units as u
+    import setigen as stg
+
+    config = stg.NoiseEstimationConfig(
+        method="sigma_clip",
+        sigma=3,
+        maxiters=5,
+        context_width=2048,
+        guard_width=64,
+        width_unit="channels",
+    )
+
+    with stg.Frame.open("observation.h5", mode="r") as frame:
+        stats = frame.estimate_noise_stats(
+            path=stg.constant_path(f_start=6095.05e6,
+                                   drift_rate=1.5 * u.Hz / u.s),
+            f_profile=stg.gaussian_f_profile(width=40 * u.Hz),
+            auto_bounding=True,
+            truncate_below=1e-3,
+            t_range=(0, 300),
+            config=config,
+        )
+        level = frame.get_intensity(snr=20, noise_stats=stats)
+
+The guard region excludes the signal neighborhood from the noise sample. The
+context region supplies nearby channels used for the estimate. Sigma clipping
+is the default because it matches the existing frame behavior while allowing
+bright outliers to be rejected.
+
+With ``path`` and ``f_profile`` supplied, ``estimate_noise_stats()`` first
+resolves the signal support. It then reads a rectangular local context:
+
+.. code-block:: text
+
+    [min_signal_channel - context_width,
+     max_signal_channel + context_width]
+
+and excludes:
+
+.. code-block:: text
+
+    [min_signal_channel - guard_width,
+     max_signal_channel + guard_width]
+
+The current implementation intentionally uses a rectangular context rather than
+row-by-row path-following. Rectangular reads are substantially friendlier to
+HDF5 and filterbank-style storage because each time range and frequency range is
+contiguous. For no-drift and modest-drift narrowband injections, this is both
+scientifically reasonable and efficient.
+
+Very large drift spans can make the rectangular context much wider than the
+actual signal neighborhood at any one time. A future path-aware mode may read
+one rectangle per time chunk and apply a vectorized row-wise mask around the
+path, but that is not the default policy today.
+
+Sigma clipping is a fast, consistent first-pass estimator, not a guarantee that
+the context is clean. It works well for sparse narrowband outliers and bright
+pixels. It can be biased by broad contamination, strong bandpass curvature, or
+an asymmetric local environment. Inspect ``NoiseStats.context_bounds``,
+``NoiseStats.excluded_bounds``, and ``NoiseStats.n_samples`` when reporting
+target-SNR injections.
+
+Current limitations
+-------------------
+
+- File-backed synthetic noise mutation is not implemented. Adding synthetic
+  noise generally requires broad full-observation mutation.
+- ``Frame.data`` on a file-backed frame materializes the full backing file for
+  compatibility. Prefer ``read_frame()`` for explicit bounded reads.
+- Copy-backed mutation currently performs a full on-disk copy up front. This is
+  memory-bounded but still pays full-file disk I/O.
+- Noise estimation currently uses one rectangular local context. Path-aware
+  chunked noise contexts and richer contamination diagnostics are planned, but
+  are not implemented yet.
+
+File-backed spectra and time series
+-----------------------------------
+
+The common ``mean`` and ``sum`` reductions are chunked for file-backed frames:
+
+.. code-block:: python
+
+    with stg.Frame.open("observation.h5", mode="r") as frame:
+        spectrum = frame.spectrum(mode="mean",
+                                  f_range=(6095.0e6, 6095.1e6),
+                                  t_range=(0, 300))
+        time_series = frame.timeseries(mode="sum",
+                                       f_index_range=(1000, 2000),
+                                       t_index_range=(0, 128))
+
+These products are returned as normal eager ``Spectrum`` and ``TimeSeries``
+objects. Their metadata records that they were produced by integration, which
+axis was collapsed, which reducer was used, and which source region was read.
+Future reducers such as median or percentile-like products may need different
+memory policies.
+
+Best practices
+--------------
+
+- Use ``Frame.open_copy()`` for injection into real observations.
+- Use ``Frame.open(..., mode="r")`` for inspection and plotting.
+- Use ``read_frame()`` to create an eager working region.
+- Use ``spectrum()`` and ``timeseries()`` directly for chunked file-backed
+  ``mean`` and ``sum`` products.
+- Keep signal bounding explicit for custom profiles.
+- Estimate SNR from a local window around the injection, with a guard region.
+- Treat ``Frame.data`` as a deliberate full-materialization request when the
+  frame is file-backed.

--- a/docs/source/frame_methods.rst
+++ b/docs/source/frame_methods.rst
@@ -19,6 +19,11 @@ As it implies, if you set the ``db`` flag to True, it will express
 the intensities in terms of decibels. This can help visualize data a little better,
 depending on the application.
 
+For file-backed frames, ``get_data()`` and ``frame.data`` materialize the full
+backing file. Use :meth:`setigen.frame.Frame.read_frame` when you only need a
+bounded region of a large observation. See :doc:`file_backed_frames` for the
+large-file workflow.
+
 Plotting frames
 ---------------
 
@@ -108,6 +113,17 @@ This function is a wrapper for :func:`setigen.frame_utils.integrate`, with the s
 ``axis`` parameter can be either 't' or 0 to integrate along the time axis, or 'f' or 
 1 to integrate along the frequency axis. The ``mode`` parameter can be either 'mean' or
 'sum' to determine the manner of integration.
+
+When ``as_frame=True``, time integration returns a
+:class:`setigen.spectrum.Spectrum` with shape ``(1, fchans)``, while frequency
+integration returns a :class:`setigen.timeseries.TimeSeries` with shape
+``(tchans, 1)``. These products preserve frame context such as source name,
+start time, headers, and custom metadata. For detailed semantics and metadata
+guidance, see :doc:`frame_products`.
+
+For file-backed frames, ``mean`` and ``sum`` spectra and time series are
+computed in chunks. The returned ``Spectrum`` or ``TimeSeries`` is eager and
+contains derived-product metadata describing the source region and reducer.
 
 Frame slicing
 -------------

--- a/docs/source/frame_products.rst
+++ b/docs/source/frame_products.rst
@@ -1,0 +1,172 @@
+.. |setigen| replace:: :mod:`setigen`
+
+Frame products and metadata
+===========================
+
+Most |setigen| workflows start with a two-dimensional :class:`setigen.Frame`:
+time on one axis, frequency on the other, and intensity values in the array.
+Common analysis operations collapse, slice, or transform that frame. The goal
+is for those derived products to preserve enough context that they remain
+scientifically interpretable.
+
+Coordinate conventions
+----------------------
+
+Internally, :class:`setigen.Frame` stores data as ``(time, frequency)`` with
+frequency channels in increasing order. The ``ascending`` flag controls how the
+frame should be written back to filterbank-style products, but frame-level
+calculations use increasing frequencies.
+
+Useful frame coordinates include:
+
+``frame.fs`` or ``frame.frequency_centers``
+    Frequency-channel center coordinates in Hz.
+
+``frame.frequency_edges``
+    Frequency-channel edges in Hz, useful for plotting and region semantics.
+
+``frame.ts`` or ``frame.time_starts``
+    Time-bin start coordinates in seconds relative to ``frame.t_start``.
+
+``frame.time_centers``
+    Time-bin centers.
+
+``frame.time_edges`` or ``frame.ts_ext``
+    Time-bin edges.
+
+When choosing between center and edge conventions, use edges for image extents
+and integrated durations. Use centers for evaluating a signal path at the
+representative time of each row.
+
+Metadata and headers
+--------------------
+
+``frame.metadata`` is the user-facing metadata dictionary. It starts with the
+core frame parameters and can be extended with run-specific information:
+
+.. code-block:: python
+
+    frame.add_metadata({
+        "drift_rate": 1.5,
+        "injection_id": "candidate-0001",
+    })
+
+``frame.header`` stores filterbank/HDF5-style observational metadata when a
+frame comes from a file or voltage reduction. Save paths rebuild critical header
+fields from the frame object, but derived products should still keep headers in
+sync when they change dimensions, start time, or frequency bounds.
+
+The current code preserves source name, start time, headers, and custom
+metadata through slicing, dedrifting, region reads, and integration. Derived
+products also attach a ``metadata["derived"]`` payload that records:
+
+- source shape
+- source time/frequency bounds
+- operation name
+- collapsed axis, when applicable
+- reducer, such as ``mean`` or ``sum``
+- normalization policy
+
+For example:
+
+.. code-block:: python
+
+    spectrum = frame.spectrum(mode="sum",
+                              f_index_range=(100, 200),
+                              t_index_range=(0, 16))
+    print(spectrum.metadata["derived"])
+
+The exact payload depends on the operation, but integration products include
+``operation``, ``product_type``, ``collapsed_axis``, ``reducer``,
+``source_shape``, and ``source_bounds``.
+
+Spectrum products
+-----------------
+
+A :class:`setigen.Spectrum` is a one-row frame with shape ``(1, fchans)``.
+It represents a frame collapsed over time:
+
+.. code-block:: python
+
+    spectrum = stg.spectrum(frame, mode="mean")
+    summed_spectrum = frame.integrate(axis="t", mode="sum", as_frame=True)
+
+For spectra:
+
+- ``df`` remains the source channel width.
+- ``dt`` is the collapsed time span represented by the product.
+- ``fch1`` follows the selected frequency span.
+- ``t_start`` is the start of the selected time span.
+
+Use ``mode="mean"`` when you want average power per time bin. Use
+``mode="sum"`` when the accumulated power over the integration is the desired
+quantity.
+
+Time-series products
+--------------------
+
+A :class:`setigen.TimeSeries` is a one-channel frame with shape
+``(tchans, 1)``. It represents a frame collapsed over frequency:
+
+.. code-block:: python
+
+    ts = stg.timeseries(frame, mode="mean")
+    summed_ts = frame.integrate(axis="f", mode="sum", as_frame=True)
+
+For time series:
+
+- ``dt`` remains the source time resolution.
+- ``df`` is the collapsed frequency bandwidth.
+- ``fch1`` is the center frequency of the collapsed band.
+- ``t_start`` is the start of the selected time span.
+
+Use ``mode="mean"`` for average power over the band. Use ``mode="sum"`` when
+the total integrated band power is desired.
+
+Normalization
+-------------
+
+Several existing APIs expose normalization options:
+
+- ``integrate(normalize=True)`` sigma-normalizes the reduced product.
+- ``Spectrum.plot(snr=True)`` plots a sigma-normalized copy.
+- ``TimeSeries.plot(norm=True)`` divides by the mean before plotting.
+
+These remain available for compatibility. For new workflows, prefer naming the
+normalization explicitly in metadata and analysis notes. A future shared
+collapse spec should distinguish at least:
+
+- no normalization
+- sigma-clipped zero-mean/unit-variance normalization
+- mean normalization
+
+File-backed products
+--------------------
+
+``spectrum()`` and ``timeseries()`` support chunked ``mean`` and ``sum``
+reductions for file-backed frames:
+
+.. code-block:: python
+
+    with stg.Frame.open("observation.h5", mode="r") as frame:
+        spectrum = frame.spectrum(f_range=(6095.0e6, 6095.1e6),
+                                  t_range=(0, 300),
+                                  mode="mean")
+        ts = frame.timeseries(f_index_range=(100, 500),
+                              mode="sum")
+
+The returned products are eager singleton-axis frames. For reducers beyond
+``mean`` and ``sum``, first read a bounded region with ``read_frame()`` unless
+the reducer explicitly documents chunked file-backed behavior.
+
+Best practices
+--------------
+
+- Keep singleton-axis ``Spectrum`` and ``TimeSeries`` products as frame-like
+  objects so plotting, units, and serialization remain consistent.
+- Use ``mode="mean"`` or ``mode="sum"`` deliberately and record that choice.
+- Preserve source context when constructing derived frames manually:
+  ``t_start``, ``source_name``, ``header``, and relevant custom metadata.
+- For large files, reduce explicit regions rather than accidental full-frame
+  materializations.
+- Treat derived metadata as part of the scientific record, not only bookkeeping.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ Welcome to setigen's documentation!
     :scale: 75
 
 |setigen|_ is a Python library for generating and injecting artificial
-narrow-band signals into radio requency data. |setigen|_ interfaces
+narrow-band signals into radio frequency data. |setigen|_ interfaces
 primarily with two types of data: spectrograms or dynamic spectra, saved in 
 two-dimensional NumPy arrays or filterbank files (``.fil`` extension), 
 and raw voltages (GUPPI RAW files). Both data formats are instrumental to 
@@ -46,9 +46,12 @@ Table of Contents
    getting_started
    basics
    frame_methods
+   file_backed_frames
+   frame_products
    advanced
    cadences
    voltages
+   array_backends
    setigen
    setigen.voltage
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -67,7 +67,8 @@ to accelerate voltage computations. Enable it with
 ``stg.voltage.set_backend('cupy')`` before constructing voltage objects. Use
 ``stg.voltage.set_backend('numpy')`` to force CPU execution. The legacy
 ``SETIGEN_ENABLE_GPU=1`` environment variable is still supported for existing
-scripts. While it isn't used directly by |setigen|,
+scripts. The current public backend API is voltage-focused; the shared
+NumPy/CuPy policy is described in :doc:`array_backends`. While it isn't used directly by |setigen|,
 you may also find it helpful to install ``cusignal`` 
 (https://github.com/rapidsai/cusignal) for access to CUDA-enabled versions of 
 ``scipy`` functions when writing custom voltage signal source functions.

--- a/docs/source/setigen.rst
+++ b/docs/source/setigen.rst
@@ -44,6 +44,22 @@ setigen.timeseries module
     :members:
     :undoc-members:
     :show-inheritance:
+
+setigen.noise module
+--------------------
+
+.. automodule:: setigen.noise
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+setigen.integrate module
+------------------------
+
+.. automodule:: setigen.integrate
+    :members:
+    :undoc-members:
+    :show-inheritance:
     
 setigen.dedrift module
 ----------------------

--- a/docs/source/voltages.rst
+++ b/docs/source/voltages.rst
@@ -227,7 +227,8 @@ In Python:
 
 The legacy ``SETIGEN_ENABLE_GPU=1`` environment variable is still supported for
 existing scripts. Use ``stg.voltage.set_backend('numpy')`` to force CPU
-execution.
+execution. See :doc:`array_backends` for the shared backend vocabulary and the
+intended package-wide policy.
     
 Details behind classes
 ----------------------

--- a/setigen/__init__.py
+++ b/setigen/__init__.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 from setigen._version import __version__
 
-from setigen.frame import Frame, params_from_backend
+from setigen.frame import Frame, frame_params_from_backend, params_from_backend
 from setigen.cadence import Cadence, OrderedCadence
 from setigen.spectrum import Spectrum
 from setigen.timeseries import TimeSeries
+from setigen.noise import NoiseEstimationConfig, NoiseStats
     
 from setigen.utils import db, array
 from setigen.unit_utils import cast_value, get_value
@@ -44,11 +45,14 @@ from setigen.split_utils import (
 __all__ = [
     "__version__",
     "Frame",
+    "frame_params_from_backend",
     "params_from_backend",
     "Cadence",
     "OrderedCadence",
     "Spectrum",
     "TimeSeries",
+    "NoiseEstimationConfig",
+    "NoiseStats",
     "db",
     "array",
     "cast_value",

--- a/setigen/_frame/construction.py
+++ b/setigen/_frame/construction.py
@@ -15,6 +15,7 @@ from blimpy import Waterfall
 
 from .. import waterfall_utils
 from .. import unit_utils
+from .io import _close_waterfall_handles
 
 
 @dataclass(frozen=True)
@@ -35,8 +36,7 @@ class _SyntheticFrameSpec:
 class _WaterfallLoadSpec:
     """Normalized specification for loading a frame from a waterfall."""
 
-    waterfall: Waterfall
-    header: object
+    header: dict[str, Any]
     df: float
     dt: float
     fch1: float
@@ -156,16 +156,18 @@ def _normalize_waterfall_init(
     """
     kwargs = {} if kwargs is None else kwargs
 
+    owns_waterfall = False
     if isinstance(waterfall, pathlib.PurePath):
         waterfall = str(waterfall)
     if isinstance(waterfall, str):
         waterfall = Waterfall(waterfall,
                               f_start=kwargs.get("f_start"),
                               f_stop=kwargs.get("f_stop"))
+        owns_waterfall = True
     elif not isinstance(waterfall, Waterfall):
         raise FileNotFoundError(f"Unsupported data type: {type(waterfall)}")
 
-    header = waterfall.header
+    header = copy.deepcopy(waterfall.header)
     tchans, _, fchans = waterfall.container.selection_shape
     shape = (tchans, fchans)
 
@@ -181,13 +183,18 @@ def _normalize_waterfall_init(
 
     t_start = Time(header["tstart"], format="mjd").unix
     source_name = header["source_name"]
+    if isinstance(source_name, bytes):
+        source_name = source_name.decode()
 
     data = waterfall_utils.get_data(waterfall)
     if not ascending:
         data = data[:, ::-1]
+    data = np.array(data, copy=True)
 
-    return _WaterfallLoadSpec(waterfall=waterfall,
-                              header=header,
+    if owns_waterfall:
+        _close_waterfall_handles(waterfall)
+
+    return _WaterfallLoadSpec(header=header,
                               df=df,
                               dt=dt,
                               fch1=fch1,
@@ -269,15 +276,15 @@ def _initialize_frame_from_spec(
     frame.data = spec.data
 
     if isinstance(spec, _WaterfallLoadSpec):
-        frame.waterfall = spec.waterfall
-        frame.header = spec.header
+        frame.waterfall = None
+        frame.header = copy.deepcopy(spec.header)
     else:
         frame.waterfall = None
         frame.header = None
 
 
 def _attach_loaded_waterfall(frame: Any, waterfall: Waterfall | None) -> None:
-    """Attach a deepcopy of a loaded waterfall to a frame.
+    """Attach serializable header metadata from a loaded waterfall to a frame.
 
     Args:
         frame: Frame instance to update.
@@ -285,8 +292,4 @@ def _attach_loaded_waterfall(frame: Any, waterfall: Waterfall | None) -> None:
     """
     if waterfall is None:
         return
-    try:
-        del waterfall.container.h5
-    except AttributeError:
-        pass
-    frame.waterfall = copy.deepcopy(waterfall)
+    frame.header = copy.deepcopy(waterfall.header)

--- a/setigen/_frame/context.py
+++ b/setigen/_frame/context.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from astropy.time import Time
+
+
+_DERIVED_METADATA_EXCLUDE_KEYS = {"file_backed", "path"}
+
+
+def _copy_custom_metadata(source: Any, target: Any) -> None:
+    """Copy non-core metadata between frame-like objects.
+
+    Args:
+        source: Original frame-like object.
+        target: Derived frame-like object to update.
+    """
+    metadata = copy.deepcopy(getattr(source, "metadata", {}))
+    try:
+        for key, value in source.get_params().items():
+            if metadata.get(key) == value:
+                metadata.pop(key)
+    except AttributeError:
+        pass
+    for key in _DERIVED_METADATA_EXCLUDE_KEYS:
+        metadata.pop(key, None)
+    if metadata:
+        target.add_metadata(metadata)
+
+
+def _frame_header_fields(frame: Any) -> dict[str, Any]:
+    """Return header fields that must match a frame's current geometry.
+
+    Args:
+        frame: Frame-like object providing observing metadata.
+
+    Returns:
+        Header fields synchronized to the frame.
+    """
+    return {
+        "source_name": frame.source_name,
+        "tsamp": frame.dt,
+        "tstart": Time(frame.t_start, format="unix").mjd,
+        "nchans": frame.fchans,
+        "nifs": 1,
+        "fch1": frame.fch1 * 1e-6,
+        "foff": frame.df * (1 if frame.ascending else -1) * 1e-6,
+    }
+
+
+def _copy_header_context(source: Any, target: Any) -> None:
+    """Copy and synchronize observational header context.
+
+    Args:
+        source: Original frame-like object.
+        target: Derived frame-like object to update.
+    """
+    source_header = getattr(source, "header", None)
+    target_header = getattr(target, "header", None)
+    if source_header is None and target_header is None:
+        return
+
+    if source_header is not None:
+        target.header = copy.deepcopy(source_header)
+    elif target_header is not None:
+        target.header = copy.deepcopy(target_header)
+    target.header.update(_frame_header_fields(target))
+
+
+def _source_bounds_metadata(
+    source: Any,
+    *,
+    f_index_range: tuple[int, int] | None = None,
+    t_index_range: tuple[int, int] | None = None,
+) -> dict[str, Any]:
+    """Build serializable bounds metadata for a derived frame.
+
+    Args:
+        source: Source frame-like object.
+        f_index_range: Half-open source frequency index range.
+        t_index_range: Half-open source time index range.
+
+    Returns:
+        Bounds metadata describing the source region.
+    """
+    f_start, f_stop = f_index_range or (0, source.fchans)
+    t_start, t_stop = t_index_range or (0, source.tchans)
+    bounds: dict[str, Any] = {
+        "time_index_range": (int(t_start), int(t_stop)),
+        "frequency_index_range": (int(f_start), int(f_stop)),
+    }
+
+    if hasattr(source, "time_edges"):
+        bounds["time_range_s"] = (
+            float(source.time_edges[t_start]),
+            float(source.time_edges[t_stop]),
+        )
+    if hasattr(source, "frequency_edges"):
+        bounds["frequency_range_hz"] = (
+            float(source.frequency_edges[f_start]),
+            float(source.frequency_edges[f_stop]),
+        )
+    return bounds
+
+
+def _finalize_derived_frame(
+    source: Any,
+    target: Any,
+    *,
+    operation: str,
+    product_type: str | None = None,
+    collapsed_axis: str | None = None,
+    reducer: str | None = None,
+    normalization: str | None = None,
+    source_bounds: dict[str, Any] | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
+    """Attach source context and operation provenance to a derived frame.
+
+    Args:
+        source: Original frame-like object.
+        target: Derived frame-like object to update.
+        operation: Operation that produced the target.
+        product_type: Optional product kind such as ``"spectrum"``.
+        collapsed_axis: Optional collapsed axis name.
+        reducer: Optional reducer name.
+        normalization: Optional normalization policy.
+        source_bounds: Optional source-region metadata.
+        extra_metadata: Optional additional operation metadata.
+    """
+    _copy_custom_metadata(source, target)
+    _copy_header_context(source, target)
+
+    derived = {
+        "operation": operation,
+        "source_shape": tuple(getattr(source, "shape", ())),
+    }
+    if product_type is not None:
+        derived["product_type"] = product_type
+    if collapsed_axis is not None:
+        derived["collapsed_axis"] = collapsed_axis
+    if reducer is not None:
+        derived["reducer"] = reducer
+    if normalization is not None:
+        derived["normalization"] = normalization
+    if source_bounds is not None:
+        derived["source_bounds"] = copy.deepcopy(source_bounds)
+    if extra_metadata:
+        derived.update(copy.deepcopy(extra_metadata))
+    target.add_metadata({"derived": derived})
+
+
+def _copy_frame_context(source: Any, target: Any) -> None:
+    """Copy non-shape observational context between frame-like objects.
+
+    Args:
+        source: Original frame-like object.
+        target: Derived frame-like object to update.
+    """
+    _copy_custom_metadata(source, target)
+    _copy_header_context(source, target)

--- a/setigen/_frame/file_mutation.py
+++ b/setigen/_frame/file_mutation.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .signal import (
+    _evaluate_path_values,
+    _finalize_signal,
+    _get_restricted_fs,
+    _normalize_bp_profile,
+    _normalize_path,
+    _normalize_t_profile,
+    _render_signal,
+    _resolve_auto_bounding_range,
+    _resolve_bounding_indices,
+)
+
+
+@dataclass(frozen=True)
+class FileBackedSignalResult:
+    """Summary of a memory-bounded file-backed signal injection."""
+
+    shape: tuple[int, int]
+    frequency_slice: slice
+    time_chunks: int
+    max_chunk_shape: tuple[int, int]
+
+
+class _ChunkFrameView:
+    """Small frame-like view used to reuse signal rendering helpers per chunk."""
+
+    def __init__(self,
+                 source: Any,
+                 *,
+                 t_start_index: int,
+                 tchans: int,
+                 f_start_index: int,
+                 f_stop_index: int,
+                 data: np.ndarray) -> None:
+        """Create a chunk view with frame-like axes and data.
+
+        Args:
+            source: Full source frame.
+            t_start_index: Absolute time-bin start index for this chunk.
+            tchans: Number of time bins in this chunk.
+            f_start_index: Absolute frequency-channel start index.
+            f_stop_index: Absolute frequency-channel stop index.
+            data: Chunk data in internal `Frame` orientation.
+        """
+        self.df = source.df
+        self.dt = source.dt
+        self.ascending = source.ascending
+        self.t_start = source.t_start + t_start_index * source.dt
+        self.source_name = source.source_name
+        self.fchans = f_stop_index - f_start_index
+        self.tchans = tchans
+        self.shape = (tchans, self.fchans)
+        self.fs = source.fs[f_start_index:f_stop_index]
+        if self.ascending:
+            self.fch1 = self.fs[0]
+        else:
+            self.fch1 = self.fs[-1]
+        self.fmin = self.fs[0]
+        self.fmax = self.fs[-1]
+        self.ts = np.linspace(0, self.tchans * self.dt, self.tchans, endpoint=False)
+        self.data = data
+
+    @property
+    def time_edges(self) -> np.ndarray:
+        """Return chunk time-bin edges in seconds."""
+        return np.linspace(0, self.tchans * self.dt, self.tchans + 1, endpoint=True)
+
+    @property
+    def ts_ext(self) -> np.ndarray:
+        """Return chunk time-bin edges for legacy signal helpers."""
+        return self.time_edges
+
+    def get_index(self, frequency: Any) -> np.ndarray:
+        """Convert frequency to the closest local chunk channel index.
+
+        Args:
+            frequency: Frequency or array of frequencies in Hz.
+
+        Returns:
+            Closest local frequency-channel index or indices.
+        """
+        return np.round((frequency - self.fmin) / self.df).astype(int)
+
+
+def _slice_time_input(value: Any,
+                      *,
+                      t_start: int,
+                      t_stop: int,
+                      full_tchans: int,
+                      doppler_smearing: bool = False) -> Any:
+    """Slice full-observation time/path arrays for one chunk.
+
+    Args:
+        value: Candidate time-dependent profile or path.
+        t_start: Inclusive chunk time-bin start index.
+        t_stop: Exclusive chunk time-bin stop index.
+        full_tchans: Number of time bins in the full frame.
+        doppler_smearing: Whether path arrays need one extra edge sample.
+
+    Returns:
+        Sliced array when `value` matches the full time axis, otherwise `value`.
+    """
+    if not isinstance(value, (list, np.ndarray)):
+        return value
+    array = np.asarray(value)
+    expected = full_tchans + int(doppler_smearing)
+    if array.shape == (expected,):
+        return array[t_start:t_stop + int(doppler_smearing)]
+    return value
+
+
+def _evaluate_t_profile_values(frame: Any,
+                               t_profile: Any,
+                               *,
+                               integrate_t_profile: bool = False,
+                               t_subsamples: int = 10,
+                               t_offset: float = 0) -> Any:
+    """Evaluate a callable time profile over the full frame once.
+
+    Args:
+        frame: Full frame defining the time axis.
+        t_profile: Time profile input.
+        integrate_t_profile: Whether to average over time subsamples.
+        t_subsamples: Number of time subsamples per bin.
+        t_offset: Time offset applied before evaluation.
+
+    Returns:
+        Full-frame time-profile array, or the original non-callable input.
+    """
+    if not callable(t_profile):
+        return t_profile
+    if integrate_t_profile:
+        ts = np.linspace(0,
+                         frame.tchans * frame.dt,
+                         frame.tchans * t_subsamples,
+                         endpoint=False) + t_offset
+        values = t_profile(ts)
+        if not isinstance(values, np.ndarray):
+            values = np.repeat(values, frame.tchans * t_subsamples)
+        return np.mean(np.reshape(values, (frame.tchans, t_subsamples)), axis=1)
+
+    values = t_profile(frame.ts + t_offset)
+    if not isinstance(values, np.ndarray):
+        values = np.full(frame.tchans, values)
+    return values
+
+
+def _choose_chunk_tchans(frame: Any,
+                         *,
+                         affected_fchans: int,
+                         max_chunk_bytes: int | None,
+                         chunk_tchans: int | None) -> int:
+    """Choose a time-chunk length from explicit or byte-budget inputs.
+
+    Args:
+        frame: File-backed frame being patched.
+        affected_fchans: Number of affected frequency channels.
+        max_chunk_bytes: Optional memory budget for one chunk.
+        chunk_tchans: Optional explicit time-bin count per chunk.
+
+    Returns:
+        Number of time bins to process per chunk.
+    """
+    if chunk_tchans is not None:
+        if chunk_tchans < 1:
+            raise ValueError("chunk_tchans must be at least 1")
+        return min(chunk_tchans, frame.tchans)
+
+    if max_chunk_bytes is None:
+        max_chunk_bytes = getattr(frame, "_max_chunk_bytes", 256 * 1024 * 1024)
+    if max_chunk_bytes < 1:
+        raise ValueError("max_chunk_bytes must be positive")
+
+    backend = frame._file_backend
+    itemsize = np.dtype(getattr(backend, "dtype", np.float32)).itemsize
+    working_arrays = 4
+    row_bytes = max(affected_fchans, 1) * itemsize * working_arrays
+    return max(1, min(frame.tchans, int(max_chunk_bytes // max(row_bytes, 1))))
+
+
+def add_signal_to_file_backed_frame(
+    frame: Any,
+    *,
+    path: Any,
+    t_profile: Any,
+    f_profile: Any,
+    bp_profile: Any = None,
+    bounding_f_range: tuple[Any, Any] | None = None,
+    integrate_path: bool = False,
+    integrate_t_profile: bool = False,
+    integrate_f_profile: bool = False,
+    doppler_smearing: bool = False,
+    t_subsamples: int = 10,
+    f_subsamples: int = 10,
+    smearing_subsamples: int = 10,
+    t_offset: float = 0,
+    auto_bounding: bool = False,
+    truncate_below: float | None = None,
+    max_chunk_bytes: int | None = None,
+    chunk_tchans: int | None = None,
+) -> FileBackedSignalResult:
+    """Patch a writable file-backed frame immediately in bounded chunks.
+
+    Args:
+        frame: Writable file-backed frame.
+        path: Signal frequency path.
+        t_profile: Signal time profile.
+        f_profile: Signal frequency profile.
+        bp_profile: Optional bandpass profile.
+        bounding_f_range: Optional frequency range limiting rendering.
+        integrate_path: Whether to integrate the path within time bins.
+        integrate_t_profile: Whether to integrate the time profile.
+        integrate_f_profile: Whether to integrate the frequency profile.
+        doppler_smearing: Whether to smear power across drift within bins.
+        t_subsamples: Number of time subsamples.
+        f_subsamples: Number of frequency subsamples.
+        smearing_subsamples: Number of Doppler-smearing substeps.
+        t_offset: Time offset for callable path/profile evaluation.
+        auto_bounding: Whether to infer bounds for known profiles.
+        truncate_below: Optional relative cutoff for infinite-support profiles.
+        max_chunk_bytes: Optional memory budget per chunk.
+        chunk_tchans: Optional explicit time bins per chunk.
+
+    Returns:
+        Summary of the patched region and chunking.
+    """
+    backend = frame._file_backend
+    if not backend.writable:
+        raise OSError(
+            "This file-backed frame is read-only. Use Frame.open_copy(...) or "
+            "Frame.open(..., mode='r+', allow_inplace=True) before add_signal()."
+        )
+
+    if doppler_smearing and smearing_subsamples < 1:
+        raise ValueError("smearing_subsamples must be at least 1 when doppler_smearing=True")
+
+    if auto_bounding and bounding_f_range is None:
+        bounding_f_range, path = _resolve_auto_bounding_range(
+            frame,
+            path,
+            f_profile,
+            integrate_path=integrate_path,
+            integrate_f_profile=integrate_f_profile,
+            doppler_smearing=doppler_smearing,
+            t_subsamples=t_subsamples,
+            t_offset=t_offset,
+            truncate_below=truncate_below,
+        )
+
+    if callable(path):
+        path = _evaluate_path_values(frame,
+                                     path,
+                                     integrate_path=integrate_path,
+                                     doppler_smearing=doppler_smearing,
+                                     t_subsamples=t_subsamples,
+                                     t_offset=t_offset)
+    if callable(t_profile):
+        t_profile = _evaluate_t_profile_values(frame,
+                                               t_profile,
+                                               integrate_t_profile=integrate_t_profile,
+                                               t_subsamples=t_subsamples,
+                                               t_offset=t_offset)
+
+    bounding_min, bounding_max = _resolve_bounding_indices(frame, bounding_f_range)
+    if bounding_min >= bounding_max:
+        return FileBackedSignalResult(shape=frame.shape,
+                                      frequency_slice=slice(bounding_min, bounding_max),
+                                      time_chunks=0,
+                                      max_chunk_shape=(0, 0))
+
+    affected_fchans = bounding_max - bounding_min
+    chunk_len = _choose_chunk_tchans(frame,
+                                     affected_fchans=affected_fchans,
+                                     max_chunk_bytes=max_chunk_bytes,
+                                     chunk_tchans=chunk_tchans)
+    chunks = 0
+    max_chunk_shape = (0, affected_fchans)
+
+    for chunk_start in range(0, frame.tchans, chunk_len):
+        chunk_stop = min(frame.tchans, chunk_start + chunk_len)
+        chunk_data = backend.read_region(chunk_start,
+                                         chunk_stop,
+                                         bounding_min,
+                                         bounding_max)
+        chunk_frame = _ChunkFrameView(frame,
+                                      t_start_index=chunk_start,
+                                      tchans=chunk_stop - chunk_start,
+                                      f_start_index=bounding_min,
+                                      f_stop_index=bounding_max,
+                                      data=chunk_data)
+        local_path = _slice_time_input(path,
+                                       t_start=chunk_start,
+                                       t_stop=chunk_stop,
+                                       full_tchans=frame.tchans,
+                                       doppler_smearing=doppler_smearing)
+        local_t_profile = _slice_time_input(t_profile,
+                                            t_start=chunk_start,
+                                            t_stop=chunk_stop,
+                                            full_tchans=frame.tchans)
+
+        restricted_fs, restricted_fchans = _get_restricted_fs(
+            chunk_frame,
+            bounding_min=0,
+            bounding_max=chunk_frame.fchans,
+            integrate_f_profile=integrate_f_profile,
+            f_subsamples=f_subsamples,
+        )
+        ff, _ = np.meshgrid(restricted_fs, chunk_frame.ts)
+
+        local_t_offset = t_offset + chunk_start * frame.dt
+        t_profile_tt = _normalize_t_profile(
+            chunk_frame,
+            restricted_fs,
+            local_t_profile,
+            integrate_t_profile=integrate_t_profile,
+            t_subsamples=t_subsamples,
+            t_offset=local_t_offset,
+        )
+        resolved_path = _normalize_path(
+            chunk_frame,
+            restricted_fs,
+            local_path,
+            integrate_path=integrate_path,
+            doppler_smearing=doppler_smearing,
+            t_subsamples=t_subsamples,
+            smearing_subsamples=smearing_subsamples,
+            t_offset=local_t_offset,
+        )
+        bp_profile_ff = _normalize_bp_profile(chunk_frame, restricted_fs, bp_profile)
+        signal = _render_signal(ff=ff,
+                                t_profile_tt=t_profile_tt,
+                                f_profile=f_profile,
+                                bp_profile_ff=bp_profile_ff,
+                                path_tt=resolved_path.path_tt,
+                                doppler_smearing=doppler_smearing,
+                                dpath_tt=resolved_path.dpath_tt,
+                                smearing_subsamples=smearing_subsamples)
+        _finalize_signal(chunk_frame,
+                         signal=signal,
+                         bounding_min=0,
+                         bounding_max=chunk_frame.fchans,
+                         integrate_f_profile=integrate_f_profile,
+                         restricted_fchans=restricted_fchans,
+                         f_subsamples=f_subsamples)
+        backend.write_region(chunk_start, bounding_min, chunk_frame.data)
+        chunks += 1
+        max_chunk_shape = (
+            max(max_chunk_shape[0], chunk_frame.data.shape[0]),
+            max(max_chunk_shape[1], chunk_frame.data.shape[1]),
+        )
+
+    backend.flush()
+    return FileBackedSignalResult(shape=frame.shape,
+                                  frequency_slice=slice(bounding_min, bounding_max),
+                                  time_chunks=chunks,
+                                  max_chunk_shape=max_chunk_shape)

--- a/setigen/_frame/io.py
+++ b/setigen/_frame/io.py
@@ -242,8 +242,10 @@ def _save_fil(frame: Any, filename: str | pathlib.Path, *, max_load: int = 1) ->
     """
     _update_waterfall(frame, filename=filename, max_load=max_load)
     _encode_bytestrings(frame)
-    frame.waterfall.write_to_fil(filename)
-    _decode_bytestrings(frame)
+    try:
+        frame.waterfall.write_to_fil(filename)
+    finally:
+        _decode_bytestrings(frame)
 
 
 def _save_hdf5(frame: Any, filename: str | pathlib.Path, *, max_load: int = 1) -> None:
@@ -256,8 +258,10 @@ def _save_hdf5(frame: Any, filename: str | pathlib.Path, *, max_load: int = 1) -
     """
     _update_waterfall(frame, filename=filename, max_load=max_load)
     _encode_bytestrings(frame)
-    frame.waterfall.write_to_hdf5(filename)
-    _decode_bytestrings(frame)
+    try:
+        frame.waterfall.write_to_hdf5(filename)
+    finally:
+        _decode_bytestrings(frame)
 
 
 def _save_npy(frame: Any, filename: str | pathlib.Path) -> None:

--- a/setigen/_frame/io.py
+++ b/setigen/_frame/io.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import pathlib
 import pickle
 from typing import Any
@@ -8,6 +9,139 @@ import numpy as np
 
 from blimpy import Waterfall
 from blimpy.io import sigproc
+
+
+def _close_waterfall_handles(waterfall: Any) -> None:
+    """Close live file handles owned by a blimpy waterfall when present.
+
+    Args:
+        waterfall: Waterfall-like object to inspect.
+    """
+    h5 = getattr(getattr(waterfall, "container", None), "h5", None)
+    if h5 is None:
+        return
+    try:
+        h5.close()
+    except Exception:
+        pass
+
+
+def _has_live_h5_handle(waterfall: Any) -> bool:
+    """Return whether a waterfall is backed by a live HDF5 file handle.
+
+    Args:
+        waterfall: Waterfall-like object to inspect.
+
+    Returns:
+        Whether the object owns a currently valid HDF5 file handle.
+    """
+    h5 = getattr(getattr(waterfall, "container", None), "h5", None)
+    if h5 is None:
+        return False
+    try:
+        return bool(h5.id.valid)
+    except Exception:
+        return True
+
+
+def _base_filterbank_header() -> dict[str, Any]:
+    """Return a packaged filterbank header template.
+
+    Returns:
+        Deep-copied SIGPROC-compatible header template.
+    """
+    path = pathlib.Path(__file__).resolve().parents[1] / "assets" / "sample.fil"
+    waterfall = Waterfall(str(path), load_data=False)
+    header = copy.deepcopy(waterfall.header)
+    _close_waterfall_handles(waterfall)
+    return header
+
+
+def _frame_waterfall_header(frame: Any) -> dict[str, Any]:
+    """Build a blimpy-compatible header from frame metadata.
+
+    Args:
+        frame: Frame instance providing scientific metadata.
+
+    Returns:
+        Header dictionary suitable for constructing a Waterfall adapter.
+    """
+    header = _base_filterbank_header()
+    if getattr(frame, "header", None) is not None:
+        header.update(copy.deepcopy(frame.header))
+
+    header.update({
+        "source_name": frame.source_name,
+        "tsamp": frame.dt,
+        "tstart": frame.mjd,
+        "nchans": frame.fchans,
+        "nifs": 1,
+        "fch1": frame.fch1 * 1e-6,
+        "foff": frame.df * (1 if frame.ascending else -1) * 1e-6,
+    })
+    header.setdefault("rawdatafile", "Synthetic")
+    header.setdefault("nbits", 32)
+    return header
+
+
+def _frame_waterfall_data(frame: Any) -> np.ndarray:
+    """Return frame data in blimpy's time/IF/frequency layout.
+
+    Args:
+        frame: Frame instance providing data and orientation metadata.
+
+    Returns:
+        Three-dimensional data array with shape ``(time, if, frequency)``.
+    """
+    data = frame.data[:, np.newaxis, :]
+    if not frame.ascending:
+        data = data[:, :, ::-1]
+    return data
+
+
+def _sync_waterfall_adapter(waterfall: Waterfall, frame: Any) -> Waterfall:
+    """Synchronize an existing in-memory waterfall adapter with a frame.
+
+    Args:
+        waterfall: Existing in-memory Waterfall adapter.
+        frame: Frame instance whose current state should be reflected.
+
+    Returns:
+        The same Waterfall adapter after metadata and data synchronization.
+    """
+    header = _frame_waterfall_header(frame)
+    data = _frame_waterfall_data(frame)
+
+    waterfall.header.clear()
+    waterfall.header.update(header)
+    waterfall.file_header = waterfall.header
+    waterfall.data = data
+
+    waterfall.n_ints_in_file = frame.tchans
+    waterfall.selection_shape = data.shape
+    waterfall.n_channels_in_file = frame.fchans
+    waterfall.file_shape = data.shape
+    waterfall.file_size_bytes = frame.tchans * frame.fchans * header["nbits"] / 8
+
+    container = waterfall.container
+    container.header = waterfall.header
+    container.n_channels_in_file = frame.fchans
+    container._n_bytes = int(header["nbits"] / 8)
+    if header["foff"] < 0:
+        container.f_end = header["fch1"]
+        container.f_begin = container.f_end + frame.fchans * header["foff"]
+    else:
+        container.f_begin = header["fch1"]
+        container.f_end = container.f_begin + frame.fchans * header["foff"]
+    container.f_start = container.f_begin
+    container.f_stop = container.f_end
+    container.t_begin = 0
+    container.t_end = frame.tchans
+    container.t_start = 0
+    container.t_stop = frame.tchans
+    container.selection_shape = data.shape
+    container.n_ints_in_file = frame.tchans
+    return waterfall
 
 
 def _create_synthetic_waterfall(frame: Any, *, max_load: int = 1) -> Waterfall:
@@ -20,42 +154,10 @@ def _create_synthetic_waterfall(frame: Any, *, max_load: int = 1) -> Waterfall:
     Returns:
         Synthetic waterfall object configured for the frame.
     """
-    path = pathlib.Path(__file__).resolve().parents[1] / "assets" / "sample.fil"
-    waterfall = Waterfall(str(path), max_load=max_load)
-    waterfall.header["source_name"] = frame.source_name
-    waterfall.header["rawdatafile"] = "Synthetic"
-
-    container_attr = {
-        "t_begin": 0,
-        "t_end": frame.tchans,
-        "file_size_bytes": frame.tchans * frame.fchans * waterfall.header["nbits"] / 8,
-        "n_channels_in_file": frame.fchans,
-        "n_ints_in_file": frame.tchans,
-        "file_shape": (frame.tchans, 1, frame.fchans),
-        "f_end": frame.fmax * 1e-6,
-        "f_begin": frame.fmin * 1e-6,
-        "f_stop": frame.fmax * 1e-6,
-        "f_start": frame.fmin * 1e-6,
-        "t_start": 0,
-        "t_stop": frame.tchans,
-        "selection_shape": (frame.tchans, 1, frame.fchans),
-        "chan_start_idx": 0,
-        "chan_stop_idx": frame.fchans,
-    }
-    for key, value in container_attr.items():
-        setattr(waterfall.container, key, value)
-
-    wat_attr = {
-        "n_channels_in_file": frame.fchans,
-        "n_ints_in_file": frame.tchans,
-        "file_shape": (frame.tchans, 1, frame.fchans),
-        "file_size_bytes": frame.tchans * frame.fchans * waterfall.header["nbits"] / 8,
-        "selection_shape": (frame.tchans, 1, frame.fchans),
-    }
-    for key, value in wat_attr.items():
-        setattr(waterfall, key, value)
-
-    return waterfall
+    del max_load
+    waterfall = Waterfall(header_dict=_frame_waterfall_header(frame),
+                          data_array=_frame_waterfall_data(frame))
+    return _sync_waterfall_adapter(waterfall, frame)
 
 
 def _update_waterfall(
@@ -71,25 +173,10 @@ def _update_waterfall(
         filename: Optional output filename to attach to the waterfall container.
         max_load: Maximum load parameter for a lazily created waterfall.
     """
-    if frame.waterfall is None:
+    if frame.waterfall is None or _has_live_h5_handle(frame.waterfall):
         frame.waterfall = _create_synthetic_waterfall(frame, max_load=max_load)
-
-    frame.waterfall.data = frame.data[:, np.newaxis, :]
-    if not frame.ascending:
-        frame.waterfall.data = frame.waterfall.data[:, :, ::-1]
-
-    header_attr = {
-        "tsamp": frame.dt,
-        "tstart": frame.mjd,
-        "nchans": frame.fchans,
-        "fch1": frame.fch1 * 1e-6,
-    }
-    if frame.ascending:
-        header_attr["foff"] = frame.df * 1e-6
     else:
-        header_attr["foff"] = frame.df * -1e-6
-    frame.waterfall.header.update(header_attr)
-    frame.waterfall.file_header.update(header_attr)
+        _sync_waterfall_adapter(frame.waterfall, frame)
 
     if filename is not None:
         frame.waterfall.container.filename = str(pathlib.Path(filename).resolve())

--- a/setigen/_frame/models.py
+++ b/setigen/_frame/models.py
@@ -386,5 +386,5 @@ def _build_constant_signal_kwargs(
         "bounding_f_range": (frame.get_frequency(bounding_min_index),
                               frame.get_frequency(bounding_max_index)),
         "doppler_smearing": config.doppler_smearing,
-        "smearing_subsamples": int(np.ceil(config.drift_rate / frame.unit_drift_rate)),
+        "smearing_subsamples": max(1, int(np.ceil(abs(config.drift_rate / frame.unit_drift_rate)))),
     }

--- a/setigen/_frame/signal.py
+++ b/setigen/_frame/signal.py
@@ -17,6 +17,153 @@ class _ResolvedSignalPath:
     dpath_tt: np.ndarray | None = None
 
 
+def _get_profile_support_half_width(
+    f_profile: FrequencyProfile,
+    truncate_below: float | None,
+) -> float | None:
+    """Resolve an auto-bounding half-width for a frequency profile.
+
+    Args:
+        f_profile: Frequency-profile callable.
+        truncate_below: Optional relative power cutoff for infinite-support
+            profiles.
+
+    Returns:
+        Half-width in Hz when a scientifically explicit support can be
+        determined, otherwise `None`.
+
+    Raises:
+        ValueError: If `truncate_below` is outside the open interval `(0, 1)`.
+    """
+    metadata = getattr(f_profile, "_setigen_profile_metadata", {})
+    if metadata.get("finite_support", False):
+        return float(metadata["half_width"])
+
+    if truncate_below is None:
+        return None
+    if not 0 < truncate_below < 1:
+        raise ValueError("truncate_below must be between 0 and 1")
+
+    profile_type = metadata.get("profile_type")
+    if profile_type == "gaussian":
+        return float(metadata["sigma"] * np.sqrt(-2 * np.log(truncate_below)))
+    if profile_type == "multiple_gaussian":
+        gaussian_width = metadata["sigma"] * np.sqrt(-2 * np.log(truncate_below))
+        return float(metadata["max_offset"] + gaussian_width)
+    if profile_type == "lorentzian":
+        return float(metadata["gamma"] * np.sqrt(1 / truncate_below - 1))
+    return None
+
+
+def _evaluate_path_values(
+    frame: Any,
+    path: FrequencyPathInput,
+    *,
+    integrate_path: bool = False,
+    doppler_smearing: bool = False,
+    t_subsamples: int = 10,
+    t_offset: float = 0,
+) -> np.ndarray:
+    """Evaluate a path on the time coordinates needed for rendering.
+
+    Args:
+        frame: Frame instance that defines the time axis.
+        path: Callable, array, or scalar signal path.
+        integrate_path: Whether to oversample in time before averaging the path.
+        doppler_smearing: Whether to include one extra time edge sample.
+        t_subsamples: Number of time subsamples per bin.
+        t_offset: Time offset applied when evaluating callable paths.
+
+    Returns:
+        Path values in Hz, with one extra value when Doppler smearing is active.
+
+    Raises:
+        TypeError: If the path type is unsupported.
+        ValueError: If an array-valued path has the wrong shape.
+    """
+    tchans_eff = frame.tchans + int(doppler_smearing)
+
+    if callable(path):
+        if integrate_path:
+            new_ts = np.linspace(0,
+                                 tchans_eff * frame.dt,
+                                 tchans_eff * t_subsamples,
+                                 endpoint=False) + t_offset
+            values = path(new_ts)
+            if not isinstance(values, np.ndarray):
+                values = np.repeat(values, tchans_eff * t_subsamples)
+            return np.mean(np.reshape(values, (tchans_eff, t_subsamples)), axis=1)
+
+        ts = frame.time_edges if doppler_smearing else frame.ts
+        values = path(ts + t_offset)
+        if not isinstance(values, np.ndarray):
+            values = np.full(tchans_eff, values)
+        return values
+
+    if isinstance(path, (list, np.ndarray)):
+        values = np.array(path)
+        if doppler_smearing:
+            if values.shape != frame.ts_ext.shape:
+                raise ValueError(f"To Doppler smear power, must provide path array with {frame.tchans + 1} values")
+        elif values.shape != frame.ts.shape:
+            raise ValueError(f"Shape of path array is {values.shape} != {frame.ts.shape}.")
+        return values
+
+    if isinstance(path, (int, float)):
+        return np.full(tchans_eff, path)
+
+    raise TypeError("path is not a function, array, or float.")
+
+
+def _resolve_auto_bounding_range(
+    frame: Any,
+    path: FrequencyPathInput,
+    f_profile: FrequencyProfile,
+    *,
+    integrate_path: bool = False,
+    integrate_f_profile: bool = False,
+    doppler_smearing: bool = False,
+    t_subsamples: int = 10,
+    t_offset: float = 0,
+    truncate_below: float | None = None,
+) -> tuple[tuple[float, float] | None, FrequencyPathInput]:
+    """Resolve an optional auto-bounding range and reusable path values.
+
+    Args:
+        frame: Frame instance that defines the axes.
+        path: Callable, array, or scalar signal path.
+        f_profile: Frequency-profile callable.
+        integrate_path: Whether path integration is enabled.
+        integrate_f_profile: Whether frequency-profile integration is enabled.
+        doppler_smearing: Whether Doppler smearing is enabled.
+        t_subsamples: Number of time subsamples per bin.
+        t_offset: Time offset applied when evaluating callable paths.
+        truncate_below: Optional relative power cutoff for infinite-support
+            profiles.
+
+    Returns:
+        Tuple of optional bounding frequency range and path input to use for
+        rendering. Callable paths are replaced by evaluated path arrays when a
+        range is resolved, preserving stochastic path consistency.
+    """
+    half_width = _get_profile_support_half_width(f_profile, truncate_below)
+    if half_width is None:
+        return None, path
+
+    path_values = _evaluate_path_values(frame,
+                                        path,
+                                        integrate_path=integrate_path,
+                                        doppler_smearing=doppler_smearing,
+                                        t_subsamples=t_subsamples,
+                                        t_offset=t_offset)
+    padding = half_width + frame.df / 2
+    if integrate_f_profile:
+        padding += frame.df / 2
+
+    return (float(np.min(path_values) - padding),
+            float(np.max(path_values) + padding)), path_values
+
+
 def _resolve_bounding_indices(
     frame: Any,
     bounding_f_range: tuple[Any, Any] | None,
@@ -71,7 +218,8 @@ def _normalize_t_profile(frame: Any,
                          t_profile: TimeProfileInput,
                          *,
                          integrate_t_profile: bool = False,
-                         t_subsamples: int = 10) -> np.ndarray:
+                         t_subsamples: int = 10,
+                         t_offset: float = 0) -> np.ndarray:
     """Normalize a time profile into a time-frequency grid.
 
     Args:
@@ -93,14 +241,14 @@ def _normalize_t_profile(frame: Any,
             new_ts = np.linspace(0,
                                  frame.tchans * frame.dt,
                                  frame.tchans * t_subsamples,
-                                 endpoint=False)
+                                 endpoint=False) + t_offset
             y = t_profile(new_ts)
             if not isinstance(y, np.ndarray):
                 y = np.repeat(y, frame.tchans * t_subsamples)
             t_profile = np.mean(np.reshape(y, (frame.tchans, t_subsamples)),
                                 axis=1)
         else:
-            t_profile = t_profile(frame.ts)
+            t_profile = t_profile(frame.ts + t_offset)
     elif isinstance(t_profile, (list, np.ndarray)):
         t_profile = np.array(t_profile)
         if t_profile.shape != frame.ts.shape:
@@ -157,7 +305,8 @@ def _normalize_path(frame: Any,
                     integrate_path: bool = False,
                     doppler_smearing: bool = False,
                     t_subsamples: int = 10,
-                    smearing_subsamples: int = 10) -> _ResolvedSignalPath:
+                    smearing_subsamples: int = 10,
+                    t_offset: float = 0) -> _ResolvedSignalPath:
     """Normalize a signal path into render-ready arrays.
 
     Args:
@@ -177,33 +326,12 @@ def _normalize_path(frame: Any,
         TypeError: If the path type is unsupported.
         ValueError: If an array-valued path has the wrong shape.
     """
-    # Generate one extra time sample for frequency-smearing calculations.
-    tchans_eff = frame.tchans + int(doppler_smearing)
-
-    if callable(path):
-        if integrate_path:
-            new_ts = np.linspace(0,
-                                 tchans_eff * frame.dt,
-                                 tchans_eff * t_subsamples,
-                                 endpoint=False)
-            f = path(new_ts)
-            if not isinstance(f, np.ndarray):
-                f = np.repeat(f, tchans_eff * t_subsamples)
-            path = np.mean(np.reshape(f, (tchans_eff, t_subsamples)), axis=1)
-        else:
-            ts = frame.ts_ext if doppler_smearing else frame.ts
-            path = path(ts)
-    elif isinstance(path, (list, np.ndarray)):
-        path = np.array(path)
-        if doppler_smearing:
-            if path.shape != frame.ts_ext.shape:
-                raise ValueError(f"To Doppler smear power, must provide path array with {frame.tchans + 1} values")
-        elif path.shape != frame.ts.shape:
-            raise ValueError(f"Shape of path array is {path.shape} != {frame.ts.shape}.")
-    elif isinstance(path, (int, float)):
-        path = np.full(tchans_eff, path)
-    else:
-        raise TypeError("path is not a function, array, or float.")
+    path = _evaluate_path_values(frame,
+                                 path,
+                                 integrate_path=integrate_path,
+                                 doppler_smearing=doppler_smearing,
+                                 t_subsamples=t_subsamples,
+                                 t_offset=t_offset)
 
     _, path_tt = np.meshgrid(restricted_fs, path[:frame.tchans])
 

--- a/setigen/_plot/axes.py
+++ b/setigen/_plot/axes.py
@@ -178,12 +178,13 @@ def _get_frame_frequency_edges(frame: Frame,
     Returns:
         Lower and upper plot edges for the frequency axis.
     """
+    frequency_edges = frame.frequency_edges
     if axis_spec.frequency_kind is _FrequencyAxisKind.FMID:
-        return frame.fmin - frame.fmid - frame.df / 2, frame.fmax - frame.fmid + frame.df / 2
+        return frequency_edges[0] - frame.fmid, frequency_edges[-1] - frame.fmid
     if axis_spec.frequency_kind is _FrequencyAxisKind.FMIN:
-        return -frame.df / 2, frame.fmax - frame.fmin + frame.df / 2
+        return frequency_edges[0] - frame.fmin, frequency_edges[-1] - frame.fmin
     if axis_spec.frequency_kind is _FrequencyAxisKind.FABS:
-        return frame.fmin - frame.df / 2, frame.fmax + frame.df / 2
+        return frequency_edges[0], frequency_edges[-1]
     return -1 / 2, frame.fchans - 1 / 2
 
 
@@ -199,7 +200,7 @@ def _get_frame_time_edges(frame: Frame,
         Lower and upper plot edges for the time axis.
     """
     if axis_spec.uses_time_units:
-        return 0, frame.tchans * frame.dt
+        return frame.time_edges[0], frame.time_edges[-1]
     return -1 / 2, frame.tchans - 1 / 2
 
 

--- a/setigen/_spectrogram/__init__.py
+++ b/setigen/_spectrogram/__init__.py
@@ -1,0 +1,5 @@
+"""Private file-backed spectrogram backends."""
+
+from .base import open_spectrogram, copy_spectrogram
+
+__all__ = ["open_spectrogram", "copy_spectrogram"]

--- a/setigen/_spectrogram/base.py
+++ b/setigen/_spectrogram/base.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import pathlib
+import shutil
+from typing import Any
+
+
+class SpectrogramBackend(ABC):
+    """Private protocol for region-based spectrogram file access."""
+
+    path: pathlib.Path
+    mode: str
+    header: dict[str, Any]
+    shape: tuple[int, int]
+    fchans: int
+    tchans: int
+    df: float
+    dt: float
+    fch1: float
+    ascending: bool
+    source_name: str
+    t_start: float
+    dtype: Any
+
+    @property
+    def writable(self) -> bool:
+        """Return whether this backend supports writes."""
+        return any(flag in self.mode for flag in ("+", "w", "a"))
+
+    @abstractmethod
+    def read_region(self,
+                    t_start: int,
+                    t_stop: int,
+                    f_start: int,
+                    f_stop: int) -> Any:
+        """Read a time/frequency region in internal `Frame` orientation.
+
+        Args:
+            t_start: Inclusive time-bin start index.
+            t_stop: Exclusive time-bin stop index.
+            f_start: Inclusive frequency-channel start index.
+            f_stop: Exclusive frequency-channel stop index.
+
+        Returns:
+            Two-dimensional array in `Frame` frequency orientation.
+        """
+
+    @abstractmethod
+    def write_region(self,
+                     t_start: int,
+                     f_start: int,
+                     data: Any) -> None:
+        """Write a time/frequency region in internal `Frame` orientation.
+
+        Args:
+            t_start: Inclusive time-bin start index.
+            f_start: Inclusive frequency-channel start index.
+            data: Two-dimensional data block in `Frame` orientation.
+        """
+
+    @abstractmethod
+    def flush(self) -> None:
+        """Flush pending writes to the backing store."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close any open file resources."""
+
+    def __enter__(self) -> "SpectrogramBackend":
+        """Return this backend for context-manager use.
+
+        Returns:
+            Open backend instance.
+        """
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        """Close this backend after context-manager use.
+
+        Args:
+            exc_type: Exception type, if the context is exiting with an error.
+            exc: Exception instance, if any.
+            tb: Traceback, if any.
+        """
+        self.close()
+
+
+def _normalize_path(path: str | pathlib.Path) -> pathlib.Path:
+    """Normalize a filesystem path for backend access.
+
+    Args:
+        path: Input path.
+
+    Returns:
+        Expanded absolute path.
+    """
+    return pathlib.Path(path).expanduser().resolve()
+
+
+def open_spectrogram(path: str | pathlib.Path, mode: str = "r") -> SpectrogramBackend:
+    """Open a spectrogram backend for a supported file type.
+
+    Args:
+        path: Input spectrogram path.
+        mode: Backend file mode.
+
+    Returns:
+        Open spectrogram backend.
+    """
+    normalized = _normalize_path(path)
+    suffix = normalized.suffix.lower()
+    if suffix in {".h5", ".hdf5"}:
+        from .h5 import H5SpectrogramBackend
+
+        return H5SpectrogramBackend(normalized, mode=mode)
+    if suffix == ".fil":
+        from .fil import FilSpectrogramBackend
+
+        return FilSpectrogramBackend(normalized, mode=mode)
+    raise ValueError(f"Unsupported spectrogram file type: {normalized.suffix}")
+
+
+def copy_spectrogram(input_path: str | pathlib.Path,
+                     output_path: str | pathlib.Path,
+                     *,
+                     overwrite: bool = False) -> pathlib.Path:
+    """Copy a spectrogram file without loading its data into memory.
+
+    Args:
+        input_path: Source spectrogram path.
+        output_path: Destination spectrogram path.
+        overwrite: Whether to replace an existing destination.
+
+    Returns:
+        Absolute destination path.
+    """
+    source = _normalize_path(input_path)
+    destination = pathlib.Path(output_path).expanduser().resolve()
+    if destination.exists() and not overwrite:
+        raise FileExistsError(f"Output file already exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    return destination

--- a/setigen/_spectrogram/fil.py
+++ b/setigen/_spectrogram/fil.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import struct
+from typing import Any
+
+import numpy as np
+from astropy.time import Time
+
+from .base import SpectrogramBackend
+
+
+_HEADER_KEYWORD_TYPES = {
+    "telescope_id": "<l",
+    "machine_id": "<l",
+    "data_type": "<l",
+    "barycentric": "<l",
+    "pulsarcentric": "<l",
+    "nbits": "<l",
+    "nsamples": "<l",
+    "nchans": "<l",
+    "nifs": "<l",
+    "nbeams": "<l",
+    "ibeam": "<l",
+    "rawdatafile": "str",
+    "source_name": "str",
+    "az_start": "<d",
+    "za_start": "<d",
+    "tstart": "<d",
+    "tsamp": "<d",
+    "fch1": "<d",
+    "foff": "<d",
+    "refdm": "<d",
+    "period": "<d",
+    "src_raj": "<d",
+    "src_dej": "<d",
+}
+
+
+def _read_keyword(handle: Any) -> tuple[str, Any]:
+    """Read one SIGPROC header keyword and value.
+
+    Args:
+        handle: Binary file handle positioned at a keyword record.
+
+    Returns:
+        Tuple of keyword name and decoded value.
+    """
+    n_raw = handle.read(4)
+    if len(n_raw) != 4:
+        raise RuntimeError("Unexpected end of file while reading SIGPROC header")
+    n_bytes = struct.unpack("<I", n_raw)[0]
+    if n_bytes > 255:
+        n_bytes = 16
+    keyword = handle.read(n_bytes).decode("ascii")
+    if keyword in {"HEADER_START", "HEADER_END"}:
+        return keyword, None
+
+    dtype = _HEADER_KEYWORD_TYPES[keyword]
+    if dtype == "<l":
+        return keyword, struct.unpack(dtype, handle.read(4))[0]
+    if dtype == "<d":
+        return keyword, struct.unpack(dtype, handle.read(8))[0]
+    if dtype == "str":
+        str_len = struct.unpack("<I", handle.read(4))[0]
+        return keyword, handle.read(str_len).decode("ascii")
+    raise RuntimeError(f"Unsupported SIGPROC header type: {dtype}")
+
+
+def _read_header(path: pathlib.Path) -> tuple[dict[str, Any], int]:
+    """Read a SIGPROC filterbank header.
+
+    Args:
+        path: Filterbank file path.
+
+    Returns:
+        Tuple of header dictionary and byte offset where data begin.
+    """
+    header: dict[str, Any] = {}
+    with open(path, "rb") as handle:
+        keyword, _ = _read_keyword(handle)
+        if keyword != "HEADER_START":
+            raise RuntimeError("Not a valid SIGPROC filterbank file")
+        while True:
+            keyword, value = _read_keyword(handle)
+            if keyword == "HEADER_END":
+                return header, handle.tell()
+            header[keyword] = value
+
+
+def _dtype_from_nbits(nbits: int) -> np.dtype:
+    """Resolve a NumPy dtype from a SIGPROC sample width.
+
+    Args:
+        nbits: Bits per sample from the filterbank header.
+
+    Returns:
+        NumPy dtype for on-disk samples.
+    """
+    if nbits == 32:
+        return np.dtype("<f4")
+    if nbits == 16:
+        return np.dtype("<u2")
+    if nbits == 8:
+        return np.dtype("u1")
+    raise ValueError(f"Unsupported filterbank sample width: {nbits} bits")
+
+
+class FilSpectrogramBackend(SpectrogramBackend):
+    """Region reader/writer for SIGPROC filterbank files."""
+
+    def __init__(self, path: pathlib.Path, mode: str = "r") -> None:
+        """Open a filterbank spectrogram backend.
+
+        Args:
+            path: Filterbank file path.
+            mode: Backend open mode.
+        """
+        self.path = path
+        self.mode = mode
+        self.header, self._data_offset = _read_header(path)
+        self._initialize_metadata()
+        file_mode = "r+b" if self.writable else "rb"
+        self._file = open(path, file_mode)
+
+    def _initialize_metadata(self) -> None:
+        """Populate frame-compatible metadata from the filterbank header."""
+        self.fchans = int(self.header["nchans"])
+        self.nifs = int(self.header.get("nifs", 1))
+        self.dtype = _dtype_from_nbits(int(self.header["nbits"]))
+        self._sample_bytes = self.dtype.itemsize
+        data_bytes = os.path.getsize(self.path) - self._data_offset
+        row_bytes = self.fchans * self.nifs * self._sample_bytes
+        if row_bytes <= 0 or data_bytes % row_bytes != 0:
+            raise ValueError("filterbank data size is inconsistent with its header")
+        self.tchans = data_bytes // row_bytes
+        self.shape = (int(self.tchans), int(self.fchans))
+        self.df = abs(float(self.header["foff"])) * 1e6
+        self.dt = float(self.header["tsamp"])
+        self.ascending = float(self.header["foff"]) > 0
+        self.fch1 = float(self.header["fch1"]) * 1e6
+        self.t_start = Time(float(self.header["tstart"]), format="mjd").unix
+        source_name = self.header.get("source_name", "")
+        if isinstance(source_name, bytes):
+            source_name = source_name.decode()
+        self.source_name = str(source_name)
+
+    def _disk_frequency_slice(self, f_start: int, f_stop: int) -> tuple[int, int, bool]:
+        """Map internal frequency indices to on-disk channel bounds.
+
+        Args:
+            f_start: Inclusive internal frequency-channel start index.
+            f_stop: Exclusive internal frequency-channel stop index.
+
+        Returns:
+            Tuple of on-disk start, on-disk stop, and whether to reverse data.
+        """
+        if not 0 <= f_start <= f_stop <= self.fchans:
+            raise IndexError("frequency region is outside the file bounds")
+        if self.ascending:
+            return f_start, f_stop, False
+        return self.fchans - f_stop, self.fchans - f_start, True
+
+    def _row_offset(self, time_index: int, if_id: int, f_start: int) -> int:
+        """Calculate the byte offset for a row window.
+
+        Args:
+            time_index: Time-bin index.
+            if_id: IF index.
+            f_start: On-disk frequency-channel start index.
+
+        Returns:
+            Byte offset from the start of the file.
+        """
+        sample_index = (time_index * self.nifs + if_id) * self.fchans + f_start
+        return self._data_offset + sample_index * self._sample_bytes
+
+    def read_region(self,
+                    t_start: int,
+                    t_stop: int,
+                    f_start: int,
+                    f_stop: int) -> np.ndarray:
+        """Read a time/frequency region from the filterbank file.
+
+        Args:
+            t_start: Inclusive time-bin start index.
+            t_stop: Exclusive time-bin stop index.
+            f_start: Inclusive frequency-channel start index.
+            f_stop: Exclusive frequency-channel stop index.
+
+        Returns:
+            Two-dimensional array in `Frame` frequency orientation.
+        """
+        if not 0 <= t_start <= t_stop <= self.tchans:
+            raise IndexError("time region is outside the file bounds")
+        disk_start, disk_stop, reverse = self._disk_frequency_slice(f_start, f_stop)
+        out = np.empty((t_stop - t_start, f_stop - f_start), dtype=self.dtype)
+        for local_t, time_index in enumerate(range(t_start, t_stop)):
+            self._file.seek(self._row_offset(time_index, 0, disk_start))
+            row = np.fromfile(self._file, dtype=self.dtype, count=disk_stop - disk_start)
+            if row.shape[0] != disk_stop - disk_start:
+                raise RuntimeError("Unexpected end of file while reading filterbank data")
+            out[local_t] = row[::-1] if reverse else row
+        return out
+
+    def write_region(self,
+                     t_start: int,
+                     f_start: int,
+                     data: np.ndarray) -> None:
+        """Write a time/frequency region to the filterbank file.
+
+        Args:
+            t_start: Inclusive time-bin start index.
+            f_start: Inclusive frequency-channel start index.
+            data: Two-dimensional data block in `Frame` orientation.
+        """
+        if not self.writable:
+            raise OSError("spectrogram backend is read-only")
+        data = np.asarray(data)
+        if data.ndim != 2:
+            raise ValueError("file-backed writes require a two-dimensional array")
+        t_stop = t_start + data.shape[0]
+        f_stop = f_start + data.shape[1]
+        if not 0 <= t_start <= t_stop <= self.tchans:
+            raise IndexError("time region is outside the file bounds")
+        disk_start, disk_stop, reverse = self._disk_frequency_slice(f_start, f_stop)
+        if disk_stop - disk_start != data.shape[1]:
+            raise ValueError("write region width does not match data width")
+        for local_t, time_index in enumerate(range(t_start, t_stop)):
+            row = data[local_t, ::-1] if reverse else data[local_t]
+            self._file.seek(self._row_offset(time_index, 0, disk_start))
+            np.asarray(row, dtype=self.dtype).tofile(self._file)
+
+    def flush(self) -> None:
+        """Flush pending filterbank writes to disk."""
+        self._file.flush()
+        os.fsync(self._file.fileno())
+
+    def close(self) -> None:
+        """Close the filterbank file handle."""
+        if not self._file.closed:
+            self._file.close()

--- a/setigen/_spectrogram/h5.py
+++ b/setigen/_spectrogram/h5.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import copy
+import pathlib
+from typing import Any
+
+import numpy as np
+from astropy.time import Time
+
+try:  # Register HDF5 filters used by BL-style products when available.
+    import hdf5plugin  # noqa: F401
+except Exception:  # pragma: no cover - uncompressed HDF5 files do not need it.
+    pass
+
+import h5py
+
+from .base import SpectrogramBackend
+
+
+def _coerce_attr(value: Any) -> Any:
+    """Convert HDF5 attribute scalar values into plain Python values.
+
+    Args:
+        value: Raw HDF5 attribute value.
+
+    Returns:
+        Decoded or scalarized value when possible.
+    """
+    if isinstance(value, bytes):
+        return value.decode()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+class H5SpectrogramBackend(SpectrogramBackend):
+    """Region reader/writer for BL-style HDF5 waterfall files."""
+
+    def __init__(self, path: pathlib.Path, mode: str = "r") -> None:
+        """Open an HDF5 spectrogram backend.
+
+        Args:
+            path: HDF5 file path.
+            mode: HDF5 open mode.
+        """
+        self.path = path
+        self.mode = mode
+        self._h5 = h5py.File(path, mode)
+        self._dataset = self._h5["data"]
+        self.header = {
+            key: _coerce_attr(value)
+            for key, value in self._dataset.attrs.items()
+        }
+        self._initialize_metadata()
+
+    def _initialize_metadata(self) -> None:
+        """Populate frame-compatible metadata from the HDF5 dataset."""
+        shape = self._dataset.shape
+        if len(shape) == 3:
+            self.tchans, self.nifs, self.fchans = shape
+        elif len(shape) == 2:
+            self.tchans, self.fchans = shape
+            self.nifs = int(self.header.get("nifs", 1))
+        else:
+            raise ValueError(f"Unsupported HDF5 data shape: {shape}")
+
+        self.shape = (int(self.tchans), int(self.fchans))
+        self.header.setdefault("nchans", self.fchans)
+        self.header.setdefault("nifs", self.nifs)
+        self.dtype = self._dataset.dtype
+        self.df = abs(float(self.header["foff"])) * 1e6
+        self.dt = float(self.header["tsamp"])
+        self.ascending = float(self.header["foff"]) > 0
+        self.fch1 = float(self.header["fch1"]) * 1e6
+        self.t_start = Time(float(self.header["tstart"]), format="mjd").unix
+        source_name = self.header.get("source_name", "")
+        if isinstance(source_name, bytes):
+            source_name = source_name.decode()
+        self.source_name = str(source_name)
+
+    def _disk_frequency_slice(self, f_start: int, f_stop: int) -> tuple[slice, bool]:
+        """Map internal frequency indices to an on-disk HDF5 slice.
+
+        Args:
+            f_start: Inclusive internal frequency-channel start index.
+            f_stop: Exclusive internal frequency-channel stop index.
+
+        Returns:
+            Tuple of on-disk slice and whether the resulting data need reversal.
+        """
+        if not 0 <= f_start <= f_stop <= self.fchans:
+            raise IndexError("frequency region is outside the file bounds")
+        if self.ascending:
+            return slice(f_start, f_stop), False
+        return slice(self.fchans - f_stop, self.fchans - f_start), True
+
+    def read_region(self,
+                    t_start: int,
+                    t_stop: int,
+                    f_start: int,
+                    f_stop: int) -> np.ndarray:
+        """Read a time/frequency region from the HDF5 dataset.
+
+        Args:
+            t_start: Inclusive time-bin start index.
+            t_stop: Exclusive time-bin stop index.
+            f_start: Inclusive frequency-channel start index.
+            f_stop: Exclusive frequency-channel stop index.
+
+        Returns:
+            Two-dimensional array in `Frame` frequency orientation.
+        """
+        if not 0 <= t_start <= t_stop <= self.tchans:
+            raise IndexError("time region is outside the file bounds")
+        freq_slice, reverse = self._disk_frequency_slice(f_start, f_stop)
+        if self._dataset.ndim == 3:
+            data = self._dataset[t_start:t_stop, 0, freq_slice]
+        else:
+            data = self._dataset[t_start:t_stop, freq_slice]
+        data = np.asarray(data)
+        if reverse:
+            data = data[:, ::-1]
+        return data
+
+    def write_region(self,
+                     t_start: int,
+                     f_start: int,
+                     data: np.ndarray) -> None:
+        """Write a time/frequency region to the HDF5 dataset.
+
+        Args:
+            t_start: Inclusive time-bin start index.
+            f_start: Inclusive frequency-channel start index.
+            data: Two-dimensional data block in `Frame` orientation.
+        """
+        if not self.writable:
+            raise OSError("spectrogram backend is read-only")
+        data = np.asarray(data)
+        if data.ndim != 2:
+            raise ValueError("file-backed writes require a two-dimensional array")
+        t_stop = t_start + data.shape[0]
+        f_stop = f_start + data.shape[1]
+        if not 0 <= t_start <= t_stop <= self.tchans:
+            raise IndexError("time region is outside the file bounds")
+        freq_slice, reverse = self._disk_frequency_slice(f_start, f_stop)
+        disk_data = data[:, ::-1] if reverse else data
+        if self._dataset.ndim == 3:
+            self._dataset[t_start:t_stop, 0, freq_slice] = disk_data
+        else:
+            self._dataset[t_start:t_stop, freq_slice] = disk_data
+
+    def flush(self) -> None:
+        """Flush pending HDF5 writes."""
+        self._h5.flush()
+
+    def close(self) -> None:
+        """Close the HDF5 file handle."""
+        if self._h5:
+            self._h5.close()
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = copy.copy(self.__dict__)
+        state["_h5"] = None
+        state["_dataset"] = None
+        return state

--- a/setigen/cadence.py
+++ b/setigen/cadence.py
@@ -182,10 +182,11 @@ class Cadence(collections.abc.MutableSequence):
             *args: Positional arguments forwarded to `Frame.add_signal()`.
             **kwargs: Keyword arguments forwarded to `Frame.add_signal()`.
         """
+        base_t_offset = kwargs.pop("t_offset", 0)
         for frame in self.frames:
-            frame.ts += frame.t_start - self.t_start
-            frame.add_signal(*args, **kwargs)
-            frame.ts -= frame.t_start - self.t_start
+            frame.add_signal(*args,
+                             t_offset=base_t_offset + frame.t_start - self.t_start,
+                             **kwargs)
         
     def apply(self, func: Callable[[_frame.Frame], Any]) -> list[Any]:
         """Apply a function to each frame in the cadence.
@@ -224,6 +225,7 @@ class Cadence(collections.abc.MutableSequence):
         c_frame.ts = np.concatenate([frame.ts + frame.t_start 
                                       for frame in self.frames],
                                      axis=0)
+        c_frame._update_noise_frame_stats()
         return c_frame
 
     def save_pickle(self, filename: PathLike) -> None:

--- a/setigen/dedrift.py
+++ b/setigen/dedrift.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+from ._frame.context import _finalize_derived_frame, _source_bounds_metadata
 from .frame import Frame
 
 
@@ -65,11 +66,24 @@ def dedrift(fr: Frame, drift_rate: float | None = None) -> Frame:
                          fch1, 
                          fr.ascending,
                          tr_data,
-                         metadata=fr.metadata,
                          seed=fr.rng,
                          t_start=fr.t_start,
-                         source_name=fr.source_name,
-                         header=fr.header)
+                         source_name=fr.source_name)
+    _finalize_derived_frame(
+        fr,
+        dd_fr,
+        operation="dedrift",
+        product_type="frame",
+        source_bounds=_source_bounds_metadata(
+            fr,
+            f_index_range=(0, fr.fchans),
+            t_index_range=(0, fr.tchans),
+        ),
+        extra_metadata={
+            "drift_rate": float(drift_rate),
+            "max_frequency_offset": int(max_offset),
+        },
+    )
 #     if dd_fr.waterfall is not None and 'source_name' in dd_fr.waterfall.header:
 #         dd_fr.waterfall.header['source_name'] += '_dedrifted'
     return dd_fr

--- a/setigen/dedrift.py
+++ b/setigen/dedrift.py
@@ -66,8 +66,10 @@ def dedrift(fr: Frame, drift_rate: float | None = None) -> Frame:
                          fr.ascending,
                          tr_data,
                          metadata=fr.metadata,
-                         waterfall=fr.check_waterfall(),
-                         seed=fr.rng)
+                         seed=fr.rng,
+                         t_start=fr.t_start,
+                         source_name=fr.source_name,
+                         header=fr.header)
 #     if dd_fr.waterfall is not None and 'source_name' in dd_fr.waterfall.header:
 #         dd_fr.waterfall.header['source_name'] += '_dedrifted'
     return dd_fr

--- a/setigen/frame.py
+++ b/setigen/frame.py
@@ -40,6 +40,7 @@ from ._frame.signal import (
     _normalize_path,
     _normalize_t_profile,
     _render_signal,
+    _resolve_auto_bounding_range,
     _resolve_bounding_indices,
 )
 
@@ -113,6 +114,9 @@ class Frame(object):
         metadata: dict[str, Any] | None = None,
         waterfall: Any = None,
         seed: SeedLike = None,
+        t_start: float | None = None,
+        source_name: str | None = None,
+        header: dict[str, Any] | None = None,
     ) -> "Frame":
         """Build a frame directly from an in-memory data array.
 
@@ -125,11 +129,19 @@ class Frame(object):
             metadata: Optional metadata to attach to the frame.
             waterfall: Optional associated waterfall object.
             seed: Random seed or generator.
+            t_start: Optional Unix start time.
+            source_name: Optional source name.
+            header: Optional filterbank-style header metadata.
 
         Returns:
             Frame populated with the supplied data.
         """
         tchans, fchans = data.shape
+        init_kwargs = {}
+        if t_start is not None:
+            init_kwargs["t_start"] = t_start
+        if source_name is not None:
+            init_kwargs["source_name"] = source_name
         frame = cls(fchans=fchans,
                     tchans=tchans,
                     df=df,
@@ -137,9 +149,12 @@ class Frame(object):
                     fch1=fch1,
                     ascending=ascending,
                     data=data,
-                    seed=seed)
+                    seed=seed,
+                    **init_kwargs)
         if metadata is not None:
             frame.add_metadata(dict(metadata))
+        if header is not None:
+            frame.header = copy.deepcopy(header)
 
         _attach_loaded_waterfall(frame, waterfall)
         return frame
@@ -222,11 +237,14 @@ class Frame(object):
             Independent frame copy.
         """
         c_frame = copy.deepcopy(self)
-        # Note that since the __getstate__ function is overwritten, we need to
-        # add back the waterfall object.
-        waterfall = self.get_waterfall()
-        if waterfall is not None:
-            c_frame.waterfall = copy.deepcopy(waterfall)
+        # Since __getstate__ excludes transient Waterfall adapters, preserve an
+        # already-created in-memory adapter when it is safe to copy. Never create
+        # a Waterfall as a side effect of copying.
+        if self.waterfall is not None:
+            try:
+                c_frame.waterfall = copy.deepcopy(self.waterfall)
+            except Exception:
+                c_frame.waterfall = None
         return c_frame
 
     def __getstate__(self) -> dict[str, Any]:
@@ -286,7 +304,37 @@ class Frame(object):
     @property 
     def ts_ext(self) -> np.ndarray:
         """Return the time axis extended by one final endpoint sample."""
-        return np.append(self.ts, self.ts[-1] + self.dt)
+        return self.time_edges
+
+    @property
+    def frequency_centers(self) -> np.ndarray:
+        """Return frequency-channel center coordinates in Hz."""
+        return self.fs
+
+    @property
+    def frequency_edges(self) -> np.ndarray:
+        """Return frequency-channel edge coordinates in Hz."""
+        return np.linspace(self.fmin - self.df / 2,
+                          self.fmax + self.df / 2,
+                          self.fchans + 1)
+
+    @property
+    def time_starts(self) -> np.ndarray:
+        """Return time-bin start coordinates in seconds."""
+        return self.ts
+
+    @property
+    def time_centers(self) -> np.ndarray:
+        """Return time-bin center coordinates in seconds."""
+        return self.ts + self.dt / 2
+
+    @property
+    def time_edges(self) -> np.ndarray:
+        """Return time-bin edge coordinates in seconds."""
+        return np.linspace(0,
+                          self.tchans * self.dt,
+                          self.tchans + 1,
+                          endpoint=True)
 
     @property
     def mean(self) -> float:
@@ -423,7 +471,10 @@ class Frame(object):
                    doppler_smearing: bool = False,
                    t_subsamples: int = 10,
                    f_subsamples: int = 10,
-                   smearing_subsamples: int = 10) -> np.ndarray:
+                   smearing_subsamples: int = 10,
+                   t_offset: float = 0,
+                   auto_bounding: bool = False,
+                   truncate_below: float | None = None) -> np.ndarray:
         """Add a synthetic signal to the frame.
 
         Args:
@@ -442,10 +493,32 @@ class Frame(object):
             t_subsamples: Number of time subsamples per bin.
             f_subsamples: Number of frequency subsamples per bin.
             smearing_subsamples: Number of substeps used for Doppler smearing.
+            t_offset: Time offset applied when evaluating callable time profiles
+                and paths. This is primarily used for cadence-level injections.
+            auto_bounding: Whether to infer a conservative frequency bounding
+                range for known built-in frequency profiles.
+            truncate_below: Optional relative power cutoff for supported
+                infinite-support profiles when `auto_bounding` is enabled.
 
         Returns:
             Two-dimensional signal array that was added to the frame.
         """
+        if doppler_smearing and smearing_subsamples < 1:
+            raise ValueError("smearing_subsamples must be at least 1 when doppler_smearing=True")
+
+        if auto_bounding and bounding_f_range is None:
+            bounding_f_range, path = _resolve_auto_bounding_range(
+                self,
+                path,
+                f_profile,
+                integrate_path=integrate_path,
+                integrate_f_profile=integrate_f_profile,
+                doppler_smearing=doppler_smearing,
+                t_subsamples=t_subsamples,
+                t_offset=t_offset,
+                truncate_below=truncate_below,
+            )
+
         bounding_min, bounding_max = _resolve_bounding_indices(self, bounding_f_range)
 
         restricted_fs, restricted_fchans = _get_restricted_fs(
@@ -461,7 +534,8 @@ class Frame(object):
                                             restricted_fs,
                                             t_profile,
                                             integrate_t_profile=integrate_t_profile,
-                                            t_subsamples=t_subsamples)
+                                            t_subsamples=t_subsamples,
+                                            t_offset=t_offset)
 
         resolved_path = _normalize_path(self,
                                         restricted_fs,
@@ -469,7 +543,8 @@ class Frame(object):
                                         integrate_path=integrate_path,
                                         doppler_smearing=doppler_smearing,
                                         t_subsamples=t_subsamples,
-                                        smearing_subsamples=smearing_subsamples)
+                                        smearing_subsamples=smearing_subsamples,
+                                        t_offset=t_offset)
 
         bp_profile_ff = _normalize_bp_profile(self, restricted_fs, bp_profile)
 
@@ -578,17 +653,32 @@ class Frame(object):
             raise ValueError('You must add noise in the image to return SNR!')
         return intensity * np.sqrt(self.tchans) / self.noise_std
 
-    def get_drift_rate(self, start_index: int, stop_index: int) -> float:
+    def get_drift_rate(self,
+                       start_index: int,
+                       stop_index: int,
+                       reference: str = "edges") -> float:
         """Calculate drift rate from pixel coordinates.
 
         Args:
             start_index: Starting frequency index.
             stop_index: Ending frequency index.
+            reference: Time reference convention. ``"edges"`` preserves the
+                historical convention that spans the full integrated
+                observation length. ``"centers"`` uses the distance between the
+                representative time labels of the first and last rows.
 
         Returns:
             Drift rate in Hz/s.
         """
-        return (stop_index - start_index) * self.df / (self.tchans * self.dt)
+        if reference in {"edges", "edge", "time_edges", "integration"}:
+            duration = self.tchans * self.dt
+        elif reference in {"centers", "center", "time_centers", "labels"}:
+            if self.tchans < 2:
+                raise ValueError("center-referenced drift rates require at least two time bins")
+            duration = (self.tchans - 1) * self.dt
+        else:
+            raise ValueError("reference must be 'edges' or 'centers'")
+        return (stop_index - start_index) * self.df / duration
 
     def get_info(self) -> dict[str, Any]:
         """Return the full frame attribute dictionary.
@@ -657,10 +747,19 @@ class Frame(object):
     @utils._copy_docstring(slice.get_slice)
     def get_slice(self, *args: Any, **kwargs: Any) -> Any:
         return slice.get_slice(self, *args, **kwargs)
-        
-    # @utils._copy_docstring(frame_utils.integrate)
-    # def integrate(self, *args, **kwargs):
-    #     return frame_utils.integrate(self, *args, **kwargs)
+
+    def integrate(self, *args: Any, **kwargs: Any) -> Any:
+        """Integrate frame data over time or frequency.
+
+        Args:
+            *args: Positional arguments forwarded to `setigen.integrate()`.
+            **kwargs: Keyword arguments forwarded to `setigen.integrate()`.
+
+        Returns:
+            Integrated array, `Spectrum`, or `TimeSeries`.
+        """
+        from .integrate import integrate
+        return integrate(self, *args, **kwargs)
         
     def get_waterfall(self) -> Any:
         """Return the current frame as an updated waterfall object.

--- a/setigen/frame.py
+++ b/setigen/frame.py
@@ -29,9 +29,10 @@ from ._frame.models import (
     _generate_sampled_noise,
 )
 from ._frame.io import (
-    _decode_bytestrings,
-    _encode_bytestrings,
-    _update_waterfall,
+    _check_waterfall,
+    _get_waterfall,
+    _save_fil,
+    _save_hdf5,
 )
 from ._frame.signal import (
     _finalize_signal,
@@ -767,8 +768,7 @@ class Frame(object):
         Returns:
             Waterfall representation of the frame.
         """
-        _update_waterfall(self)
-        return self.waterfall
+        return _get_waterfall(self)
     
     def check_waterfall(self) -> Any:
         """Return the updated attached waterfall when one exists.
@@ -777,9 +777,7 @@ class Frame(object):
             Updated waterfall object or `None` when the frame has no attached
             waterfall.
         """
-        if self.waterfall is None:
-            return None
-        return self.get_waterfall()
+        return _check_waterfall(self)
 
     def save_fil(self, filename: PathLike, max_load: int = 1) -> None:
         """Save frame data as a SIGPROC filterbank file.
@@ -788,10 +786,7 @@ class Frame(object):
             filename: Output `.fil` path.
             max_load: Maximum load parameter for a lazily created waterfall.
         """
-        _update_waterfall(self, filename=filename, max_load=max_load)
-        _encode_bytestrings(self)
-        self.waterfall.write_to_fil(filename)
-        _decode_bytestrings(self)
+        _save_fil(self, filename, max_load=max_load)
 
     def save_hdf5(self, filename: PathLike, max_load: int = 1) -> None:
         """Save frame data as an HDF5 waterfall file.
@@ -800,10 +795,7 @@ class Frame(object):
             filename: Output `.h5` path.
             max_load: Maximum load parameter for a lazily created waterfall.
         """
-        _update_waterfall(self, filename=filename, max_load=max_load)
-        _encode_bytestrings(self)
-        self.waterfall.write_to_hdf5(filename)
-        _decode_bytestrings(self)
+        _save_hdf5(self, filename, max_load=max_load)
 
     def save_h5(self, filename: PathLike, max_load: int = 1) -> None:
         """Save frame data as an HDF5 waterfall file.

--- a/setigen/frame.py
+++ b/setigen/frame.py
@@ -2,18 +2,19 @@ from __future__ import annotations
 
 import copy
 import pickle
+import warnings
 from typing import Any
 
 import numpy as np
 
 from astropy import units as u
 from astropy.time import Time
-from astropy.stats import sigma_clip
 
 from . import unit_utils
 from . import slice
 from . import plots
 from . import utils
+from .noise import NoiseEstimationConfig, NoiseStats, estimate_array_noise_stats
 from ._typing import BandpassProfileInput, FrequencyPathInput, FrequencyProfile, PathLike, SeedLike, TimeProfileInput
 from ._frame.construction import (
     _attach_loaded_waterfall,
@@ -34,7 +35,13 @@ from ._frame.io import (
     _save_fil,
     _save_hdf5,
 )
+from ._frame.file_mutation import (
+    FileBackedSignalResult,
+    add_signal_to_file_backed_frame,
+)
+from ._frame.context import _finalize_derived_frame, _source_bounds_metadata
 from ._frame.signal import (
+    _evaluate_path_values,
     _finalize_signal,
     _get_restricted_fs,
     _normalize_bp_profile,
@@ -44,6 +51,7 @@ from ._frame.signal import (
     _resolve_auto_bounding_range,
     _resolve_bounding_indices,
 )
+from ._spectrogram import copy_spectrogram, open_spectrogram
 
 class Frame(object):
     """Represent synthetic or waterfall-backed SETI spectrogram data."""
@@ -172,6 +180,126 @@ class Frame(object):
             Frame loaded from the supplied waterfall.
         """
         return cls(waterfall=waterfall, seed=seed)
+
+    @classmethod
+    def open(
+        cls,
+        path: PathLike,
+        *,
+        mode: str = "r",
+        allow_inplace: bool = False,
+        seed: SeedLike = None,
+        max_chunk_bytes: int = 256 * 1024 * 1024,
+    ) -> "Frame":
+        """Open a spectrogram as a file-backed frame.
+
+        Args:
+            path: Input `.fil`, `.h5`, or `.hdf5` path.
+            mode: File mode. Use `"r"` for read-only access. Writable modes
+                require `allow_inplace=True`.
+            allow_inplace: Explicit guard for direct mutation of the supplied
+                path.
+            seed: Random seed or generator.
+            max_chunk_bytes: Default memory budget for chunked file-backed
+                signal injection.
+
+        Returns:
+            File-backed frame.
+
+        Raises:
+            ValueError: If a writable mode is requested without
+                `allow_inplace=True`.
+        """
+        if mode not in {"r", "r+"}:
+            raise ValueError("Frame.open() currently supports only mode='r' and mode='r+'")
+        wants_write = any(flag in mode for flag in ("+", "w", "a"))
+        if wants_write and not allow_inplace:
+            raise ValueError(
+                "Writable file-backed frames can modify their backing file. "
+                "Use Frame.open_copy(...) for safe copy-backed mutation, or "
+                "pass allow_inplace=True when direct mutation is intended."
+            )
+        backend = open_spectrogram(path, mode=mode)
+        return cls._from_file_backend(backend,
+                                      seed=seed,
+                                      max_chunk_bytes=max_chunk_bytes)
+
+    @classmethod
+    def open_copy(
+        cls,
+        input_path: PathLike,
+        output_path: PathLike,
+        *,
+        overwrite: bool = False,
+        seed: SeedLike = None,
+        max_chunk_bytes: int = 256 * 1024 * 1024,
+    ) -> "Frame":
+        """Create and open a writable copy-backed spectrogram frame.
+
+        The input file is copied on disk without loading the full observation
+        into memory. Mutating methods patch the output file immediately.
+
+        Args:
+            input_path: Source `.fil`, `.h5`, or `.hdf5` path.
+            output_path: Writable output path to create.
+            overwrite: Whether to replace an existing output file.
+            seed: Random seed or generator.
+            max_chunk_bytes: Default memory budget for chunked file-backed
+                signal injection.
+
+        Returns:
+            File-backed frame whose backing store is `output_path`.
+        """
+        copied_path = copy_spectrogram(input_path, output_path, overwrite=overwrite)
+        backend = open_spectrogram(copied_path, mode="r+")
+        return cls._from_file_backend(backend,
+                                      seed=seed,
+                                      max_chunk_bytes=max_chunk_bytes)
+
+    @classmethod
+    def _from_file_backend(
+        cls,
+        backend: Any,
+        *,
+        seed: SeedLike = None,
+        max_chunk_bytes: int = 256 * 1024 * 1024,
+    ) -> "Frame":
+        """Build a `Frame` around an already-open file backend.
+
+        Args:
+            backend: Open spectrogram backend.
+            seed: Random seed or generator.
+            max_chunk_bytes: Default memory budget for chunked injection.
+
+        Returns:
+            File-backed frame instance.
+        """
+        frame = cls.__new__(cls)
+        frame.rng = np.random.default_rng(seed)
+        frame._file_backend = backend
+        frame._max_chunk_bytes = max_chunk_bytes
+        frame._data = None
+        frame.df = backend.df
+        frame.dt = backend.dt
+        frame.fch1 = backend.fch1
+        frame.ascending = backend.ascending
+        frame.t_start = backend.t_start
+        frame.source_name = backend.source_name
+        frame.shape = backend.shape
+        frame.tchans, frame.fchans = backend.shape
+        frame.waterfall = None
+        frame.header = copy.deepcopy(backend.header)
+        frame.chi2_df = 4 * round(frame.df * frame.dt)
+        frame.unit_drift_rate = frame.df / frame.dt
+        frame._update_fs()
+        frame._update_ts()
+        frame.noise_mean = 0
+        frame.noise_std = 0
+        frame.noise_stats = None
+        frame.metadata = frame.get_params()
+        frame.metadata["file_backed"] = True
+        frame.metadata["path"] = str(backend.path)
+        return frame
     
     @classmethod
     def from_backend_params(cls,
@@ -212,11 +340,11 @@ class Frame(object):
         elif fchans is None:
             raise ValueError("Value not given for fchans")
             
-        param_dict = params_from_backend(obs_length=obs_length,
-                                         sample_rate=sample_rate,
-                                         num_branches=num_branches,
-                                         fftlength=fftlength,
-                                         int_factor=int_factor)
+        param_dict = frame_params_from_backend(obs_length=obs_length,
+                                               sample_rate=sample_rate,
+                                               num_branches=num_branches,
+                                               fftlength=fftlength,
+                                               int_factor=int_factor)
         if data is not None:
             if param_dict['tchans'] != tchans:
                 raise ValueError(
@@ -237,6 +365,8 @@ class Frame(object):
         Returns:
             Independent frame copy.
         """
+        if self.is_file_backed:
+            return self.read_frame()
         c_frame = copy.deepcopy(self)
         # Since __getstate__ excludes transient Waterfall adapters, preserve an
         # already-created in-memory adapter when it is safe to copy. Never create
@@ -253,7 +383,67 @@ class Frame(object):
         # can't be pickled -- note that this affects copy!
         state = self.__dict__.copy()
         state['waterfall'] = None
+        state['_file_backend'] = None
         return state
+
+    @property
+    def data(self) -> np.ndarray:
+        """Return frame data, reading a full file-backed frame when needed."""
+        backend = getattr(self, "_file_backend", None)
+        if backend is not None:
+            return backend.read_region(0, self.tchans, 0, self.fchans)
+        return self._data
+
+    @data.setter
+    def data(self, value: np.ndarray | None) -> None:
+        """Replace frame data, writing through when file-backed.
+
+        Args:
+            value: New two-dimensional frame data, or `None`.
+        """
+        backend = getattr(self, "_file_backend", None)
+        if backend is None:
+            self._data = value
+            return
+        if value is None:
+            self._data = None
+            return
+        array = np.asarray(value)
+        if array.shape != self.shape:
+            raise ValueError(f"Data shape {array.shape} does not match frame shape {self.shape}.")
+        backend.write_region(0, 0, array)
+        backend.flush()
+        self._data = None
+
+    @property
+    def is_file_backed(self) -> bool:
+        """Whether this frame reads from a backing spectrogram file."""
+        return getattr(self, "_file_backend", None) is not None
+
+    def close(self) -> None:
+        """Close any file-backed resources owned by this frame."""
+        backend = getattr(self, "_file_backend", None)
+        if backend is not None:
+            backend.close()
+            self._file_backend = None
+
+    def __enter__(self) -> "Frame":
+        """Return this frame for context-manager use.
+
+        Returns:
+            Open frame instance.
+        """
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        """Close file-backed resources after context-manager use.
+
+        Args:
+            exc_type: Exception type, if any.
+            exc: Exception instance, if any.
+            tb: Traceback, if any.
+        """
+        self.close()
 
     def _update_fs(self) -> None:
         """Update the frame frequency axis and derived bounds."""
@@ -365,17 +555,235 @@ class Frame(object):
 
     def _update_noise_frame_stats(self) -> None:
         """Update sigma-clipped noise statistics for the frame."""
-        clipped_data = sigma_clip(self.data,
-                                  sigma=3,
-                                  maxiters=5,
-                                  masked=False)
-        self.noise_mean = np.mean(clipped_data)
-        self.noise_std = np.std(clipped_data)
+        if self.is_file_backed:
+            self.noise_mean = 0
+            self.noise_std = 0
+            self.noise_stats = None
+            return
+        stats = estimate_array_noise_stats(
+            self.data,
+            time_bounds=(0, self.tchans),
+            context_bounds=(0, self.fchans),
+        )
+        self.noise_stats = stats
+        self.noise_mean = stats.mean
+        self.noise_std = stats.std
+
+    def _width_to_channels(self,
+                           width: int | float,
+                           *,
+                           width_unit: str = "channels") -> int:
+        """Convert a frequency/context width into channel units.
+
+        Args:
+            width: Width in channels or frequency units.
+            width_unit: Whether `width` is in channels or Hz.
+
+        Returns:
+            Non-negative integer channel width.
+        """
+        if width_unit in {"Hz", "hz"}:
+            return max(0, int(np.ceil(unit_utils.get_value(width, u.Hz) / self.df)))
+        return max(0, int(np.ceil(width)))
+
+    def _resolve_noise_signal_bounds(
+        self,
+        *,
+        path: FrequencyPathInput | None = None,
+        f_profile: FrequencyProfile | None = None,
+        bounding_f_range: tuple[Any, Any] | None = None,
+        auto_bounding: bool = False,
+        truncate_below: float | None = None,
+        integrate_path: bool = False,
+        integrate_f_profile: bool = False,
+        doppler_smearing: bool = False,
+        t_subsamples: int = 10,
+        t_offset: float = 0,
+    ) -> tuple[int, int] | None:
+        """Resolve optional signal inputs into frequency-channel bounds.
+
+        Args:
+            path: Optional signal path.
+            f_profile: Optional frequency profile for automatic bounding.
+            bounding_f_range: Optional explicit signal bounding range.
+            auto_bounding: Whether to infer bounds for known frequency profiles.
+            truncate_below: Optional cutoff for infinite-support profiles.
+            integrate_path: Whether path integration is enabled.
+            integrate_f_profile: Whether frequency-profile integration is enabled.
+            doppler_smearing: Whether Doppler smearing is enabled.
+            t_subsamples: Number of time subsamples.
+            t_offset: Time offset for callable path evaluation.
+
+        Returns:
+            Optional half-open frequency-channel bounds.
+        """
+        if bounding_f_range is None and auto_bounding:
+            if path is None or f_profile is None:
+                raise ValueError("auto_bounding noise estimation requires path and f_profile")
+            bounding_f_range, _ = _resolve_auto_bounding_range(
+                self,
+                path,
+                f_profile,
+                integrate_path=integrate_path,
+                integrate_f_profile=integrate_f_profile,
+                doppler_smearing=doppler_smearing,
+                t_subsamples=t_subsamples,
+                t_offset=t_offset,
+                truncate_below=truncate_below,
+            )
+
+        if bounding_f_range is not None:
+            bounds = _resolve_bounding_indices(self, bounding_f_range)
+            if bounds[0] >= bounds[1]:
+                center = min(max(bounds[0], 0), self.fchans - 1)
+                return center, center + 1
+            return bounds
+
+        if path is None:
+            return None
+
+        path_values = _evaluate_path_values(self,
+                                            path,
+                                            integrate_path=integrate_path,
+                                            doppler_smearing=doppler_smearing,
+                                            t_subsamples=t_subsamples,
+                                            t_offset=t_offset)
+        bounds = _resolve_bounding_indices(
+            self,
+            (float(np.min(path_values)), float(np.max(path_values))),
+        )
+        if bounds[0] >= bounds[1]:
+            center = min(max(bounds[0], 0), self.fchans - 1)
+            return center, center + 1
+        return bounds
+
+    def estimate_noise_stats(
+        self,
+        *,
+        path: FrequencyPathInput | None = None,
+        f_profile: FrequencyProfile | None = None,
+        bounding_f_range: tuple[Any, Any] | None = None,
+        f_range: tuple[Any, Any] | None = None,
+        t_range: tuple[Any, Any] | None = None,
+        f_index_range: tuple[int, int] | None = None,
+        t_index_range: tuple[int, int] | None = None,
+        auto_bounding: bool = False,
+        truncate_below: float | None = None,
+        integrate_path: bool = False,
+        integrate_f_profile: bool = False,
+        doppler_smearing: bool = False,
+        t_subsamples: int = 10,
+        t_offset: float = 0,
+        config: NoiseEstimationConfig | None = None,
+    ) -> NoiseStats:
+        """Estimate noise statistics for an eager or file-backed frame.
+
+        Args:
+            path: Optional signal path used to define local context.
+            f_profile: Optional frequency profile used for automatic bounds.
+            bounding_f_range: Optional explicit signal bounding range.
+            f_range: Optional direct frequency range for stats.
+            t_range: Optional time range for stats.
+            f_index_range: Optional direct half-open frequency index range.
+            t_index_range: Optional direct half-open time index range.
+            auto_bounding: Whether to infer signal bounds for known profiles.
+            truncate_below: Optional cutoff for infinite-support profiles.
+            integrate_path: Whether path integration is enabled.
+            integrate_f_profile: Whether frequency-profile integration is enabled.
+            doppler_smearing: Whether Doppler smearing is enabled.
+            t_subsamples: Number of time subsamples.
+            t_offset: Time offset for callable path evaluation.
+            config: Noise-estimation configuration.
+
+        Returns:
+            Structured noise statistics.
+        """
+        resolved_config = NoiseEstimationConfig() if config is None else config
+        if self.is_file_backed and all(value is None for value in (
+            path,
+            bounding_f_range,
+            f_range,
+            f_index_range,
+            t_range,
+            t_index_range,
+        )):
+            raise ValueError(
+                "File-backed noise estimation requires an explicit path, "
+                "frequency range, or time/frequency index range."
+            )
+
+        t_start, t_stop = self._resolve_time_index_range(
+            t_range=t_range,
+            t_index_range=t_index_range,
+        )
+        signal_bounds = self._resolve_noise_signal_bounds(
+            path=path,
+            f_profile=f_profile,
+            bounding_f_range=bounding_f_range,
+            auto_bounding=auto_bounding,
+            truncate_below=truncate_below,
+            integrate_path=integrate_path,
+            integrate_f_profile=integrate_f_profile,
+            doppler_smearing=doppler_smearing,
+            t_subsamples=t_subsamples,
+            t_offset=t_offset,
+        )
+
+        excluded_bounds = None
+        if signal_bounds is not None:
+            signal_start, signal_stop = signal_bounds
+            context_chans = self._width_to_channels(
+                resolved_config.context_width,
+                width_unit=resolved_config.width_unit,
+            )
+            guard_chans = self._width_to_channels(
+                resolved_config.guard_width,
+                width_unit=resolved_config.width_unit,
+            )
+            f_start = max(0, signal_start - context_chans)
+            f_stop = min(self.fchans, signal_stop + context_chans)
+            excluded_bounds = (max(0, signal_start - guard_chans),
+                               min(self.fchans, signal_stop + guard_chans))
+        else:
+            f_start, f_stop = self._resolve_frequency_index_range(
+                f_range=f_range,
+                f_index_range=f_index_range,
+            )
+
+        if f_start >= f_stop or t_start >= t_stop:
+            raise ValueError("Requested noise-estimation region is empty")
+
+        backend = getattr(self, "_file_backend", None)
+        if backend is not None:
+            data = backend.read_region(t_start, t_stop, f_start, f_stop)
+        else:
+            data = np.asarray(self.data[t_start:t_stop, f_start:f_stop])
+
+        if excluded_bounds is not None:
+            exclude_start = max(excluded_bounds[0], f_start) - f_start
+            exclude_stop = min(excluded_bounds[1], f_stop) - f_start
+            mask = np.ones(data.shape, dtype=bool)
+            mask[:, exclude_start:exclude_stop] = False
+            data = data[mask]
+            if data.size == 0:
+                raise ValueError("Noise-estimation guard removed all context samples")
+
+        return estimate_array_noise_stats(data,
+                                          config=resolved_config,
+                                          context_bounds=(f_start, f_stop),
+                                          excluded_bounds=excluded_bounds,
+                                          time_bounds=(t_start, t_stop))
 
     def zero_data(self) -> None:
         """Reset frame data and cached noise statistics to zero."""
         self.data = np.zeros(self.shape)
         self.noise_mean = self.noise_std = 0
+        self.noise_stats = NoiseStats(mean=0,
+                                      std=0,
+                                      n_samples=int(np.prod(self.shape)),
+                                      method="constant",
+                                      context_bounds=(0, self.fchans),
+                                      time_bounds=(0, self.tchans))
 
     def add_noise(self,
                   x_mean: float,
@@ -396,6 +804,12 @@ class Frame(object):
         Raises:
             ValueError: If Gaussian noise is requested without `x_std`.
         """
+        if self.is_file_backed:
+            raise NotImplementedError(
+                "add_noise() is not implemented for file-backed frames because "
+                "it would require full-observation mutation. Read a region with "
+                "read_frame() or use an eager Frame for synthetic noise."
+            )
         noise, x_mean, x_std = _generate_noise(
             _NoiseConfig.from_values(x_mean=x_mean,
                                      x_std=x_std,
@@ -411,6 +825,12 @@ class Frame(object):
         set_to_param = (self.noise_mean == self.noise_std == 0)
         if set_to_param:
             self.noise_mean, self.noise_std = x_mean, x_std
+            self.noise_stats = NoiseStats(mean=float(x_mean),
+                                          std=float(x_std),
+                                          n_samples=int(np.prod(self.shape)),
+                                          method="parameter",
+                                          context_bounds=(0, self.fchans),
+                                          time_bounds=(0, self.tchans))
         else:
             self._update_noise_frame_stats()
 
@@ -438,6 +858,11 @@ class Frame(object):
             IndexError: If shared-index sampling is requested for mismatched
                 parameter arrays.
         """
+        if self.is_file_backed:
+            raise NotImplementedError(
+                "add_noise_from_obs() is not implemented for file-backed frames. "
+                "Use read_frame() for a bounded eager region first."
+            )
         noise, x_mean, x_std = _generate_sampled_noise(
             _SampledNoiseConfig.from_values(x_mean_array=x_mean_array,
                                             x_std_array=x_std_array,
@@ -455,6 +880,12 @@ class Frame(object):
         set_to_param = (self.noise_mean == self.noise_std == 0)
         if set_to_param:
             self.noise_mean, self.noise_std = x_mean, x_std
+            self.noise_stats = NoiseStats(mean=float(x_mean),
+                                          std=float(x_std),
+                                          n_samples=int(np.prod(self.shape)),
+                                          method="sampled_parameter",
+                                          context_bounds=(0, self.fchans),
+                                          time_bounds=(0, self.tchans))
         else:
             self._update_noise_frame_stats()
 
@@ -475,7 +906,9 @@ class Frame(object):
                    smearing_subsamples: int = 10,
                    t_offset: float = 0,
                    auto_bounding: bool = False,
-                   truncate_below: float | None = None) -> np.ndarray:
+                   truncate_below: float | None = None,
+                   max_chunk_bytes: int | None = None,
+                   chunk_tchans: int | None = None) -> np.ndarray | FileBackedSignalResult:
         """Add a synthetic signal to the frame.
 
         Args:
@@ -500,10 +933,35 @@ class Frame(object):
                 range for known built-in frequency profiles.
             truncate_below: Optional relative power cutoff for supported
                 infinite-support profiles when `auto_bounding` is enabled.
+            max_chunk_bytes: Optional memory budget for file-backed injection.
+            chunk_tchans: Optional time-chunk size for file-backed injection.
 
         Returns:
-            Two-dimensional signal array that was added to the frame.
+            Two-dimensional signal array that was added to an in-memory frame,
+            or a file-backed injection summary for file-backed frames.
         """
+        if self.is_file_backed:
+            return add_signal_to_file_backed_frame(
+                self,
+                path=path,
+                t_profile=t_profile,
+                f_profile=f_profile,
+                bp_profile=bp_profile,
+                bounding_f_range=bounding_f_range,
+                integrate_path=integrate_path,
+                integrate_t_profile=integrate_t_profile,
+                integrate_f_profile=integrate_f_profile,
+                doppler_smearing=doppler_smearing,
+                t_subsamples=t_subsamples,
+                f_subsamples=f_subsamples,
+                smearing_subsamples=smearing_subsamples,
+                t_offset=t_offset,
+                auto_bounding=auto_bounding,
+                truncate_below=truncate_below,
+                max_chunk_bytes=max_chunk_bytes,
+                chunk_tchans=chunk_tchans,
+            )
+
         if doppler_smearing and smearing_subsamples < 1:
             raise ValueError("smearing_subsamples must be at least 1 when doppler_smearing=True")
 
@@ -572,7 +1030,7 @@ class Frame(object):
                             level: float,
                             width: Any,
                             f_profile_type: str = 'sinc2',
-                            doppler_smearing: bool = False) -> np.ndarray:
+                            doppler_smearing: bool = False) -> np.ndarray | FileBackedSignalResult:
         """Add a constant-intensity, constant-drift signal to the frame.
 
         Args:
@@ -584,7 +1042,8 @@ class Frame(object):
             doppler_smearing: Whether to numerically smear power across bins.
 
         Returns:
-            Two-dimensional signal array that was added to the frame.
+            Two-dimensional signal array for in-memory frames, or a
+            file-backed injection summary for file-backed frames.
         """
         f_start = unit_utils.get_value(f_start, u.Hz)
         drift_rate = unit_utils.get_value(drift_rate, u.Hz / u.s)
@@ -622,11 +1081,14 @@ class Frame(object):
         """
         return self.fmin + self.df * index
 
-    def get_intensity(self, snr: float) -> float:
+    def get_intensity(self,
+                      snr: float,
+                      noise_stats: NoiseStats | tuple[float, float] | None = None) -> float:
         """Calculate signal intensity from SNR using the frame noise estimate.
 
         Args:
             snr: Desired signal-to-noise ratio.
+            noise_stats: Optional explicit noise statistics.
 
         Returns:
             Signal intensity that corresponds to the requested SNR.
@@ -634,15 +1096,28 @@ class Frame(object):
         Raises:
             ValueError: If the frame does not yet contain measurable noise.
         """
-        if self.noise_std == 0:
-            raise ValueError('You must add noise in the image to specify SNR!')
-        return snr * self.noise_std / np.sqrt(self.tchans)
+        if noise_stats is None:
+            noise_std = self.noise_std
+            tchans = self.tchans
+        elif isinstance(noise_stats, NoiseStats):
+            noise_std = noise_stats.std
+            tchans = noise_stats.tchans or self.tchans
+        else:
+            noise_std = noise_stats[1]
+            tchans = self.tchans
 
-    def get_snr(self, intensity: float) -> float:
+        if noise_std == 0:
+            raise ValueError('You must add noise in the image to specify SNR!')
+        return snr * noise_std / np.sqrt(tchans)
+
+    def get_snr(self,
+                intensity: float,
+                noise_stats: NoiseStats | tuple[float, float] | None = None) -> float:
         """Calculate SNR from signal intensity using the frame noise estimate.
 
         Args:
             intensity: Signal intensity.
+            noise_stats: Optional explicit noise statistics.
 
         Returns:
             Signal-to-noise ratio for the supplied intensity.
@@ -650,9 +1125,19 @@ class Frame(object):
         Raises:
             ValueError: If the frame does not yet contain measurable noise.
         """
-        if self.noise_std == 0:
+        if noise_stats is None:
+            noise_std = self.noise_std
+            tchans = self.tchans
+        elif isinstance(noise_stats, NoiseStats):
+            noise_std = noise_stats.std
+            tchans = noise_stats.tchans or self.tchans
+        else:
+            noise_std = noise_stats[1]
+            tchans = self.tchans
+
+        if noise_std == 0:
             raise ValueError('You must add noise in the image to return SNR!')
-        return intensity * np.sqrt(self.tchans) / self.noise_std
+        return intensity * np.sqrt(tchans) / noise_std
 
     def get_drift_rate(self,
                        start_index: int,
@@ -713,9 +1198,129 @@ class Frame(object):
         Returns:
             Frame data array.
         """
+        data = self.data
         if db:
-            return 10 * np.log10(self.data)
-        return self.data
+            return 10 * np.log10(data)
+        return data
+
+    def _resolve_frequency_index_range(
+        self,
+        *,
+        f_range: tuple[Any, Any] | None = None,
+        f_index_range: tuple[int, int] | None = None,
+    ) -> tuple[int, int]:
+        """Resolve frequency selection inputs to half-open channel bounds.
+
+        Args:
+            f_range: Optional frequency range in Hz or frequency units.
+            f_index_range: Optional half-open frequency index range.
+
+        Returns:
+            Clipped half-open frequency index bounds.
+        """
+        if f_index_range is not None:
+            start, stop = f_index_range
+            return max(0, int(start)), min(self.fchans, int(stop))
+        if f_range is None:
+            return 0, self.fchans
+        f0 = unit_utils.get_value(f_range[0], u.Hz)
+        f1 = unit_utils.get_value(f_range[1], u.Hz)
+        f_min, f_max = sorted((f0, f1))
+        start = int(np.searchsorted(self.fs, f_min, side="left"))
+        stop = int(np.searchsorted(self.fs, f_max, side="right"))
+        return max(0, start), min(self.fchans, stop)
+
+    def _resolve_time_index_range(
+        self,
+        *,
+        t_range: tuple[Any, Any] | None = None,
+        t_index_range: tuple[int, int] | None = None,
+    ) -> tuple[int, int]:
+        """Resolve time selection inputs to half-open time-bin bounds.
+
+        Args:
+            t_range: Optional time range in seconds or time units.
+            t_index_range: Optional half-open time index range.
+
+        Returns:
+            Clipped half-open time index bounds.
+        """
+        if t_index_range is not None:
+            start, stop = t_index_range
+            return max(0, int(start)), min(self.tchans, int(stop))
+        if t_range is None:
+            return 0, self.tchans
+        t0 = unit_utils.get_value(t_range[0], u.s)
+        t1 = unit_utils.get_value(t_range[1], u.s)
+        t_min, t_max = sorted((t0, t1))
+        start = int(np.floor(t_min / self.dt))
+        stop = int(np.ceil(t_max / self.dt))
+        return max(0, start), min(self.tchans, stop)
+
+    def read_frame(
+        self,
+        *,
+        f_range: tuple[Any, Any] | None = None,
+        t_range: tuple[Any, Any] | None = None,
+        f_index_range: tuple[int, int] | None = None,
+        t_index_range: tuple[int, int] | None = None,
+    ) -> "Frame":
+        """Read a time/frequency region as an eager in-memory frame.
+
+        Args:
+            f_range: Optional frequency range in Hz or frequency units.
+            t_range: Optional time range in seconds or time units, relative to
+                this frame start.
+            f_index_range: Optional half-open frequency index range.
+            t_index_range: Optional half-open time index range.
+
+        Returns:
+            Eager `Frame` containing the requested region.
+        """
+        f_start, f_stop = self._resolve_frequency_index_range(
+            f_range=f_range,
+            f_index_range=f_index_range,
+        )
+        t_start, t_stop = self._resolve_time_index_range(
+            t_range=t_range,
+            t_index_range=t_index_range,
+        )
+        if f_start >= f_stop or t_start >= t_stop:
+            raise ValueError("Requested frame region is empty")
+
+        backend = getattr(self, "_file_backend", None)
+        if backend is not None:
+            data = backend.read_region(t_start, t_stop, f_start, f_stop)
+        else:
+            data = np.array(self.data[t_start:t_stop, f_start:f_stop], copy=True)
+
+        if self.ascending:
+            fch1 = self.fs[f_start]
+        else:
+            fch1 = self.fs[f_stop - 1]
+
+        new_frame = Frame.from_data(
+            df=self.df,
+            dt=self.dt,
+            fch1=fch1,
+            ascending=self.ascending,
+            data=data,
+            seed=self.rng,
+            t_start=self.t_start + t_start * self.dt,
+            source_name=self.source_name,
+        )
+        _finalize_derived_frame(
+            self,
+            new_frame,
+            operation="read_frame",
+            product_type="frame",
+            source_bounds=_source_bounds_metadata(
+                self,
+                f_index_range=(f_start, f_stop),
+                t_index_range=(t_start, t_stop),
+            ),
+        )
+        return new_frame
 
     def get_metadata(self) -> dict[str, Any]:
         """Return attached frame metadata.
@@ -761,6 +1366,32 @@ class Frame(object):
         """
         from .integrate import integrate
         return integrate(self, *args, **kwargs)
+
+    def spectrum(self, *args: Any, **kwargs: Any) -> Any:
+        """Integrate this frame over time and return a `Spectrum`.
+
+        Args:
+            *args: Positional arguments forwarded to `setigen.spectrum()`.
+            **kwargs: Keyword arguments forwarded to `setigen.spectrum()`.
+
+        Returns:
+            Integrated spectrum.
+        """
+        from .integrate import spectrum
+        return spectrum(self, *args, **kwargs)
+
+    def timeseries(self, *args: Any, **kwargs: Any) -> Any:
+        """Integrate this frame over frequency and return a `TimeSeries`.
+
+        Args:
+            *args: Positional arguments forwarded to `setigen.timeseries()`.
+            **kwargs: Keyword arguments forwarded to `setigen.timeseries()`.
+
+        Returns:
+            Integrated time series.
+        """
+        from .integrate import timeseries
+        return timeseries(self, *args, **kwargs)
         
     def get_waterfall(self) -> Any:
         """Return the current frame as an updated waterfall object.
@@ -845,11 +1476,11 @@ class Frame(object):
             return pickle.load(f)
 
     
-def params_from_backend(obs_length: float = 300, 
-                        sample_rate: float = 3e9, 
-                        num_branches: int = 1024,
-                        fftlength: int = 1048576,
-                        int_factor: int = 51) -> dict[str, float]:
+def frame_params_from_backend(obs_length: float = 300,
+                              sample_rate: float = 3e9,
+                              num_branches: int = 1024,
+                              fftlength: int = 1048576,
+                              int_factor: int = 51) -> dict[str, float]:
     """Return frame parameters implied by backend characteristics.
 
     Args:
@@ -860,7 +1491,8 @@ def params_from_backend(obs_length: float = 300,
         int_factor: Fine-channel integration factor.
 
     Returns:
-        Dictionary containing `tchans`, `df`, and `dt`.
+        Dictionary containing `tchans`, `df`, and `dt` suitable for expansion
+        into `Frame(...)`.
     """
     chan_bw = sample_rate / num_branches
     df = chan_bw / fftlength
@@ -873,3 +1505,36 @@ def params_from_backend(obs_length: float = 300,
         'df': df,
         'dt': dt
     }
+
+
+def params_from_backend(obs_length: float = 300,
+                        sample_rate: float = 3e9,
+                        num_branches: int = 1024,
+                        fftlength: int = 1048576,
+                        int_factor: int = 51) -> dict[str, float]:
+    """Return frame parameters implied by backend characteristics.
+
+    Deprecated:
+        Use `frame_params_from_backend()` instead.
+
+    Args:
+        obs_length: Observation length in seconds.
+        sample_rate: Real-voltage sample rate in Hz.
+        num_branches: Number of PFB branches.
+        fftlength: Fine-channel FFT length.
+        int_factor: Fine-channel integration factor.
+
+    Returns:
+        Dictionary containing `tchans`, `df`, and `dt` suitable for expansion
+        into `Frame(...)`.
+    """
+    warnings.warn(
+        "params_from_backend() is deprecated; use frame_params_from_backend() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return frame_params_from_backend(obs_length=obs_length,
+                                     sample_rate=sample_rate,
+                                     num_branches=num_branches,
+                                     fftlength=fftlength,
+                                     int_factor=int_factor)

--- a/setigen/funcs/f_profiles.py
+++ b/setigen/funcs/f_profiles.py
@@ -17,6 +17,20 @@ from setigen._typing import FrequencyProfile
 from setigen.funcs import func_utils
 
 
+def _with_profile_metadata(profile: FrequencyProfile, **metadata: float | bool | str) -> FrequencyProfile:
+    """Attach setigen-specific support metadata to a frequency profile.
+
+    Args:
+        profile: Frequency-profile callable to annotate.
+        **metadata: Metadata describing finite support or cutoff parameters.
+
+    Returns:
+        The same frequency-profile callable.
+    """
+    profile._setigen_profile_metadata = metadata
+    return profile
+
+
 class WidthMode(str, Enum):
     """Supported width interpretations for sinc-squared profiles."""
 
@@ -53,7 +67,9 @@ def box_f_profile(width: float | u.Quantity) -> FrequencyProfile:
 
     def f_profile(f, f_center):
         return (np.abs(f - f_center) < width / 2).astype(int)
-    return f_profile
+    return _with_profile_metadata(f_profile,
+                                  finite_support=True,
+                                  half_width=width / 2)
 
 
 def gaussian_f_profile(width: float | u.Quantity) -> FrequencyProfile:
@@ -71,7 +87,10 @@ def gaussian_f_profile(width: float | u.Quantity) -> FrequencyProfile:
 
     def f_profile(f, f_center):
         return func_utils.gaussian(f, f_center, sigma)
-    return f_profile
+    return _with_profile_metadata(f_profile,
+                                  finite_support=False,
+                                  profile_type="gaussian",
+                                  sigma=sigma)
 
 
 def multiple_gaussian_f_profile(width: float | u.Quantity) -> FrequencyProfile:
@@ -92,7 +111,11 @@ def multiple_gaussian_f_profile(width: float | u.Quantity) -> FrequencyProfile:
         return func_utils.gaussian(f, f_center - 100, sigma) / 4 \
             + func_utils.gaussian(f, f_center, sigma) \
             + func_utils.gaussian(f, f_center + 100, sigma) / 4
-    return f_profile
+    return _with_profile_metadata(f_profile,
+                                  finite_support=False,
+                                  profile_type="multiple_gaussian",
+                                  sigma=sigma,
+                                  max_offset=100)
 
 
 def lorentzian_f_profile(width: float | u.Quantity) -> FrequencyProfile:
@@ -109,7 +132,10 @@ def lorentzian_f_profile(width: float | u.Quantity) -> FrequencyProfile:
 
     def f_profile(f, f_center):
         return func_utils.lorentzian(f, f_center, gamma)
-    return f_profile
+    return _with_profile_metadata(f_profile,
+                                  finite_support=False,
+                                  profile_type="lorentzian",
+                                  gamma=gamma)
 
 
 def voigt_f_profile(g_width: float | u.Quantity, l_width: float | u.Quantity) -> FrequencyProfile:
@@ -131,7 +157,11 @@ def voigt_f_profile(g_width: float | u.Quantity, l_width: float | u.Quantity) ->
 
     def f_profile(f, f_center):
         return func_utils.voigt(f, f_center, sigma, gamma) / func_utils.voigt(f_center, f_center, sigma, gamma)
-    return f_profile
+    return _with_profile_metadata(f_profile,
+                                  finite_support=False,
+                                  profile_type="voigt",
+                                  sigma=sigma,
+                                  gamma=gamma)
 
 
 def sinc2_f_profile(
@@ -165,4 +195,7 @@ def sinc2_f_profile(
                             0)**2
         else:
             return np.sinc((f - f_center) / zero_crossing)**2
-    return f_profile
+    return _with_profile_metadata(f_profile,
+                                  finite_support=trunc,
+                                  profile_type="sinc2",
+                                  half_width=zero_crossing)

--- a/setigen/integrate.py
+++ b/setigen/integrate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from enum import Enum
 from typing import Any
 
@@ -54,6 +55,27 @@ def _resolve_integration_mode(mode: IntegrationMode | str) -> IntegrationMode:
     return IntegrationMode.MEAN
 
 
+def _copy_frame_context(source: Any, target: Any) -> None:
+    """Copy non-shape observational context between frame-like objects.
+
+    Args:
+        source: Original frame-like object.
+        target: Derived frame-like object to update.
+    """
+    metadata = copy.deepcopy(getattr(source, "metadata", {}))
+    try:
+        for key, value in source.get_params().items():
+            if metadata.get(key) == value:
+                metadata.pop(key)
+    except AttributeError:
+        pass
+    if metadata:
+        target.add_metadata(metadata)
+
+    if hasattr(source, "header"):
+        target.header = copy.deepcopy(source.header)
+
+
 def integrate(
     fr: Any,
     axis: IntegrationAxis | str | int = 't',
@@ -101,7 +123,9 @@ def integrate(
                                 fch1=fr.fmid,
                                 ascending=fr.ascending,
                                 data=data,
-                                seed=fr.rng)
+                                seed=fr.rng,
+                                t_start=fr.t_start,
+                                source_name=fr.source_name)
         else:
             # Spectrum
             new_fr = Spectrum(df=fr.df,
@@ -109,7 +133,10 @@ def integrate(
                               fch1=fr.fch1,
                               ascending=fr.ascending,
                               data=data,
-                              seed=fr.rng)
+                              seed=fr.rng,
+                              t_start=fr.t_start,
+                              source_name=fr.source_name)
+        _copy_frame_context(fr, new_fr)
         return new_fr
     else:
         return data.flatten()

--- a/setigen/integrate.py
+++ b/setigen/integrate.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import copy
 from enum import Enum
 from typing import Any
 
 import numpy as np
 from astropy.stats import sigma_clip
 from . import utils
+from ._frame.context import _finalize_derived_frame, _source_bounds_metadata
 from .spectrum import Spectrum 
 from .timeseries import TimeSeries
 
@@ -34,7 +34,14 @@ def _resolve_integration_axis(axis: IntegrationAxis | str | int) -> IntegrationA
     Returns:
         Normalized integration-axis enum value.
     """
-    if axis in [IntegrationAxis.FREQUENCY, IntegrationAxis.FREQUENCY.value, 1]:
+    if isinstance(axis, IntegrationAxis):
+        return axis
+    if isinstance(axis, str):
+        normalized = axis.lower()
+        if normalized in {"f", "freq", "frequency", "frequencies"}:
+            return IntegrationAxis.FREQUENCY
+        return IntegrationAxis.TIME
+    if axis == 1:
         return IntegrationAxis.FREQUENCY
     return IntegrationAxis.TIME
 
@@ -55,25 +62,220 @@ def _resolve_integration_mode(mode: IntegrationMode | str) -> IntegrationMode:
     return IntegrationMode.MEAN
 
 
-def _copy_frame_context(source: Any, target: Any) -> None:
-    """Copy non-shape observational context between frame-like objects.
+def _resolve_region(
+    fr: Any,
+    *,
+    f_range: tuple[Any, Any] | None = None,
+    t_range: tuple[Any, Any] | None = None,
+    f_index_range: tuple[int, int] | None = None,
+    t_index_range: tuple[int, int] | None = None,
+) -> tuple[int, int, int, int]:
+    """Resolve optional frame-region selectors.
 
     Args:
-        source: Original frame-like object.
-        target: Derived frame-like object to update.
-    """
-    metadata = copy.deepcopy(getattr(source, "metadata", {}))
-    try:
-        for key, value in source.get_params().items():
-            if metadata.get(key) == value:
-                metadata.pop(key)
-    except AttributeError:
-        pass
-    if metadata:
-        target.add_metadata(metadata)
+        fr: Frame-like input or array.
+        f_range: Optional physical frequency range.
+        t_range: Optional relative time range.
+        f_index_range: Optional half-open frequency index range.
+        t_index_range: Optional half-open time index range.
 
-    if hasattr(source, "header"):
-        target.header = copy.deepcopy(source.header)
+    Returns:
+        Half-open frequency and time bounds.
+    """
+    range_values = (f_range, t_range, f_index_range, t_index_range)
+    if not hasattr(fr, "_resolve_frequency_index_range"):
+        if any(value is not None for value in range_values):
+            raise ValueError("Region selections require a Frame-like input")
+        data = np.asarray(utils.array(fr))
+        return 0, data.shape[1], 0, data.shape[0]
+
+    f_start, f_stop = fr._resolve_frequency_index_range(
+        f_range=f_range,
+        f_index_range=f_index_range,
+    )
+    t_start, t_stop = fr._resolve_time_index_range(
+        t_range=t_range,
+        t_index_range=t_index_range,
+    )
+    if f_start >= f_stop or t_start >= t_stop:
+        raise ValueError("Requested integration region is empty")
+    return f_start, f_stop, t_start, t_stop
+
+
+def _chunk_limits(
+    fr: Any,
+    *,
+    fchans: int,
+    max_chunk_bytes: int | None,
+) -> tuple[int, int]:
+    """Choose conservative file-backed time/frequency chunk limits.
+
+    Args:
+        fr: File-backed frame.
+        fchans: Selected frequency-channel count.
+        max_chunk_bytes: Optional byte budget.
+
+    Returns:
+        Tuple of `(time_chunk_tchans, frequency_chunk_fchans)`.
+    """
+    if max_chunk_bytes is None:
+        max_chunk_bytes = getattr(fr, "_max_chunk_bytes", 256 * 1024 * 1024)
+    if max_chunk_bytes < 1:
+        raise ValueError("max_chunk_bytes must be positive")
+
+    backend = fr._file_backend
+    itemsize = np.dtype(getattr(backend, "dtype", np.float32)).itemsize
+    f_chunk = max(1, min(fchans, max_chunk_bytes // itemsize))
+    t_chunk = max(1, max_chunk_bytes // max(f_chunk * itemsize, 1))
+    return int(t_chunk), int(f_chunk)
+
+
+def _integrate_eager_region(
+    fr: Any,
+    *,
+    axis: IntegrationAxis,
+    mode: IntegrationMode,
+    f_start: int,
+    f_stop: int,
+    t_start: int,
+    t_stop: int,
+) -> np.ndarray:
+    """Integrate an eager frame or array region.
+
+    Args:
+        fr: Eager frame-like input or array.
+        axis: Axis to collapse.
+        mode: Reduction mode.
+        f_start: Frequency start index.
+        f_stop: Frequency stop index.
+        t_start: Time start index.
+        t_stop: Time stop index.
+
+    Returns:
+        Reduced two-dimensional singleton-axis array.
+    """
+    if hasattr(fr, "data"):
+        data = np.asarray(fr.data[t_start:t_stop, f_start:f_stop])
+    else:
+        data = np.asarray(utils.array(fr))[t_start:t_stop, f_start:f_stop]
+    np_axis = 1 if axis is IntegrationAxis.FREQUENCY else 0
+    if mode is IntegrationMode.SUM:
+        return np.sum(data, axis=np_axis, keepdims=True)
+    return np.mean(data, axis=np_axis, keepdims=True)
+
+
+def _integrate_file_backed_region(
+    fr: Any,
+    *,
+    axis: IntegrationAxis,
+    mode: IntegrationMode,
+    f_start: int,
+    f_stop: int,
+    t_start: int,
+    t_stop: int,
+    max_chunk_bytes: int | None,
+) -> np.ndarray:
+    """Integrate a file-backed frame region in bounded chunks.
+
+    Args:
+        fr: File-backed frame.
+        axis: Axis to collapse.
+        mode: Reduction mode.
+        f_start: Frequency start index.
+        f_stop: Frequency stop index.
+        t_start: Time start index.
+        t_stop: Time stop index.
+        max_chunk_bytes: Optional byte budget.
+
+    Returns:
+        Reduced two-dimensional singleton-axis array.
+    """
+    backend = fr._file_backend
+    selected_tchans = t_stop - t_start
+    selected_fchans = f_stop - f_start
+    t_chunk, f_chunk = _chunk_limits(fr,
+                                     fchans=selected_fchans,
+                                     max_chunk_bytes=max_chunk_bytes)
+
+    if axis is IntegrationAxis.TIME:
+        output = np.zeros(selected_fchans, dtype=np.float64)
+        for local_f_start in range(0, selected_fchans, f_chunk):
+            local_f_stop = min(selected_fchans, local_f_start + f_chunk)
+            accumulator = np.zeros(local_f_stop - local_f_start, dtype=np.float64)
+            for chunk_start in range(t_start, t_stop, t_chunk):
+                chunk_stop = min(t_stop, chunk_start + t_chunk)
+                data = backend.read_region(
+                    chunk_start,
+                    chunk_stop,
+                    f_start + local_f_start,
+                    f_start + local_f_stop,
+                )
+                accumulator += np.sum(data, axis=0)
+            if mode is IntegrationMode.MEAN:
+                accumulator /= selected_tchans
+            output[local_f_start:local_f_stop] = accumulator
+        return output[np.newaxis, :]
+
+    output = np.zeros(selected_tchans, dtype=np.float64)
+    for chunk_start in range(t_start, t_stop, t_chunk):
+        chunk_stop = min(t_stop, chunk_start + t_chunk)
+        row_accumulator = np.zeros(chunk_stop - chunk_start, dtype=np.float64)
+        for local_f_start in range(0, selected_fchans, f_chunk):
+            local_f_stop = min(selected_fchans, local_f_start + f_chunk)
+            data = backend.read_region(
+                chunk_start,
+                chunk_stop,
+                f_start + local_f_start,
+                f_start + local_f_stop,
+            )
+            row_accumulator += np.sum(data, axis=1)
+        if mode is IntegrationMode.MEAN:
+            row_accumulator /= selected_fchans
+        output[chunk_start - t_start:chunk_stop - t_start] = row_accumulator
+    return output[:, np.newaxis]
+
+
+def _normalize_reduced_data(data: np.ndarray) -> np.ndarray:
+    """Sigma-normalize a reduced product.
+
+    Args:
+        data: Reduced singleton-axis product.
+
+    Returns:
+        Sigma-normalized data.
+    """
+    c_data = sigma_clip(data)
+    return (data - np.mean(c_data)) / np.std(c_data)
+
+
+def _region_fch1(fr: Any, f_start: int, f_stop: int) -> float:
+    """Return frame-convention `fch1` for a selected frequency region.
+
+    Args:
+        fr: Source frame.
+        f_start: Half-open frequency start index.
+        f_stop: Half-open frequency stop index.
+
+    Returns:
+        First-channel frequency in the frame's storage convention.
+    """
+    if fr.ascending:
+        return fr.fs[f_start]
+    return fr.fs[f_stop - 1]
+
+
+def _region_center_frequency(fr: Any, f_start: int, f_stop: int) -> float:
+    """Return center frequency for a selected frequency region.
+
+    Args:
+        fr: Source frame.
+        f_start: Half-open frequency start index.
+        f_stop: Half-open frequency stop index.
+
+    Returns:
+        Center frequency in Hz.
+    """
+    return float((fr.frequency_edges[f_start] + fr.frequency_edges[f_stop]) / 2)
 
 
 def integrate(
@@ -82,6 +284,12 @@ def integrate(
     mode: IntegrationMode | str = 'mean',
     normalize: bool = False,
     as_frame: bool = False,
+    *,
+    f_range: tuple[Any, Any] | None = None,
+    t_range: tuple[Any, Any] | None = None,
+    f_index_range: tuple[int, int] | None = None,
+    t_index_range: tuple[int, int] | None = None,
+    max_chunk_bytes: int | None = None,
 ) -> np.ndarray | Spectrum | TimeSeries:
     """Integrate frame data over time or frequency.
 
@@ -91,80 +299,169 @@ def integrate(
         mode: Integration mode.
         normalize: Whether to sigma-normalize the integrated result.
         as_frame: Whether to return a `Spectrum` or `TimeSeries` object.
+        f_range: Optional physical frequency range to select before reduction.
+        t_range: Optional relative time range to select before reduction.
+        f_index_range: Optional half-open frequency index range.
+        t_index_range: Optional half-open time index range.
+        max_chunk_bytes: Optional file-backed reduction memory budget.
 
     Returns:
         Integrated one-dimensional data or frame-like object.
     """
-    # If `data` is a Frame object, just grab its data
-    data = utils.array(fr)
     resolved_axis = _resolve_integration_axis(axis)
     resolved_mode = _resolve_integration_mode(mode)
-    if resolved_axis is IntegrationAxis.FREQUENCY:
-        # Time series
-        axis = 1
+    f_start, f_stop, t_start, t_stop = _resolve_region(
+        fr,
+        f_range=f_range,
+        t_range=t_range,
+        f_index_range=f_index_range,
+        t_index_range=t_index_range,
+    )
+
+    if getattr(fr, "is_file_backed", False):
+        data = _integrate_file_backed_region(
+            fr,
+            axis=resolved_axis,
+            mode=resolved_mode,
+            f_start=f_start,
+            f_stop=f_stop,
+            t_start=t_start,
+            t_stop=t_stop,
+            max_chunk_bytes=max_chunk_bytes,
+        )
     else:
-        # Spectrum
-        axis = 0
-        
-    if resolved_mode is IntegrationMode.SUM:
-        data = np.sum(data, axis=axis, keepdims=True)
-    else:
-        data = np.mean(data, axis=axis, keepdims=True)
+        data = _integrate_eager_region(
+            fr,
+            axis=resolved_axis,
+            mode=resolved_mode,
+            f_start=f_start,
+            f_stop=f_stop,
+            t_start=t_start,
+            t_stop=t_stop,
+        )
         
     if normalize:
-        c_data = sigma_clip(data)
-        data = (data - np.mean(c_data)) / np.std(c_data)
+        data = _normalize_reduced_data(data)
 
     if as_frame:
+        if not hasattr(fr, "df"):
+            raise TypeError("as_frame=True requires a Frame-like input")
+        source_bounds = _source_bounds_metadata(
+            fr,
+            f_index_range=(f_start, f_stop),
+            t_index_range=(t_start, t_stop),
+        )
+        normalization = "sigma_clip" if normalize else None
         if resolved_axis is IntegrationAxis.FREQUENCY:
             # Time series
-            new_fr = TimeSeries(df=fr.df * fr.fchans,
+            new_fr = TimeSeries(df=fr.df * (f_stop - f_start),
                                 dt=fr.dt,
-                                fch1=fr.fmid,
+                                fch1=_region_center_frequency(fr, f_start, f_stop),
                                 ascending=fr.ascending,
                                 data=data,
                                 seed=fr.rng,
-                                t_start=fr.t_start,
+                                t_start=fr.t_start + t_start * fr.dt,
                                 source_name=fr.source_name)
+            product_type = "timeseries"
+            collapsed_axis = "frequency"
         else:
             # Spectrum
             new_fr = Spectrum(df=fr.df,
-                              dt=fr.dt * fr.tchans,
-                              fch1=fr.fch1,
+                              dt=fr.dt * (t_stop - t_start),
+                              fch1=_region_fch1(fr, f_start, f_stop),
                               ascending=fr.ascending,
                               data=data,
                               seed=fr.rng,
-                              t_start=fr.t_start,
+                              t_start=fr.t_start + t_start * fr.dt,
                               source_name=fr.source_name)
-        _copy_frame_context(fr, new_fr)
+            product_type = "spectrum"
+            collapsed_axis = "time"
+        _finalize_derived_frame(
+            fr,
+            new_fr,
+            operation="integrate",
+            product_type=product_type,
+            collapsed_axis=collapsed_axis,
+            reducer=resolved_mode.value,
+            normalization=normalization,
+            source_bounds=source_bounds,
+        )
         return new_fr
     else:
         return data.flatten()
 
 
-def spectrum(fr: Any, mode: IntegrationMode | str = "mean", normalize: bool = False) -> Spectrum:
+def spectrum(
+    fr: Any,
+    mode: IntegrationMode | str = "mean",
+    normalize: bool = False,
+    *,
+    f_range: tuple[Any, Any] | None = None,
+    t_range: tuple[Any, Any] | None = None,
+    f_index_range: tuple[int, int] | None = None,
+    t_index_range: tuple[int, int] | None = None,
+    max_chunk_bytes: int | None = None,
+) -> Spectrum:
     """Produce a `Spectrum` from a spectrogram frame.
 
     Args:
         fr: Input frame or array-like object.
         mode: Integration mode.
         normalize: Whether to sigma-normalize the result.
+        f_range: Optional physical frequency range to select before reduction.
+        t_range: Optional relative time range to select before reduction.
+        f_index_range: Optional half-open frequency index range.
+        t_index_range: Optional half-open time index range.
+        max_chunk_bytes: Optional file-backed reduction memory budget.
 
     Returns:
         Integrated spectrum.
     """
-    return integrate(fr, axis=0, mode=mode, normalize=normalize, as_frame=True) 
+    return integrate(fr,
+                     axis=IntegrationAxis.TIME,
+                     mode=mode,
+                     normalize=normalize,
+                     as_frame=True,
+                     f_range=f_range,
+                     t_range=t_range,
+                     f_index_range=f_index_range,
+                     t_index_range=t_index_range,
+                     max_chunk_bytes=max_chunk_bytes)
 
 
-def timeseries(fr: Any, mode: IntegrationMode | str = "mean", normalize: bool = False) -> TimeSeries:
+def timeseries(
+    fr: Any,
+    mode: IntegrationMode | str = "mean",
+    normalize: bool = False,
+    *,
+    f_range: tuple[Any, Any] | None = None,
+    t_range: tuple[Any, Any] | None = None,
+    f_index_range: tuple[int, int] | None = None,
+    t_index_range: tuple[int, int] | None = None,
+    max_chunk_bytes: int | None = None,
+) -> TimeSeries:
     """Produce a `TimeSeries` from a spectrogram frame.
 
     Args:
         fr: Input frame or array-like object.
         mode: Integration mode.
         normalize: Whether to sigma-normalize the result.
+        f_range: Optional physical frequency range to select before reduction.
+        t_range: Optional relative time range to select before reduction.
+        f_index_range: Optional half-open frequency index range.
+        t_index_range: Optional half-open time index range.
+        max_chunk_bytes: Optional file-backed reduction memory budget.
 
     Returns:
         Integrated time series.
     """
-    return integrate(fr, axis=1, mode=mode, normalize=normalize, as_frame=True)
+    return integrate(fr,
+                     axis=IntegrationAxis.FREQUENCY,
+                     mode=mode,
+                     normalize=normalize,
+                     as_frame=True,
+                     f_range=f_range,
+                     t_range=t_range,
+                     f_index_range=f_index_range,
+                     t_index_range=t_index_range,
+                     max_chunk_bytes=max_chunk_bytes)

--- a/setigen/noise.py
+++ b/setigen/noise.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from astropy.stats import sigma_clip
+
+
+@dataclass(frozen=True)
+class NoiseEstimationConfig:
+    """Configuration for estimating spectrogram noise statistics."""
+
+    method: str = "sigma_clip"
+    sigma: float = 3
+    maxiters: int = 5
+    context_width: int | float = 2048
+    guard_width: int | float = 64
+    width_unit: str = "channels"
+    combine: str = "pooled"
+
+    def __post_init__(self) -> None:
+        """Validate configuration values after dataclass initialization."""
+        if self.method not in {"sigma_clip", "median_mad"}:
+            raise ValueError("method must be 'sigma_clip' or 'median_mad'")
+        if self.sigma <= 0:
+            raise ValueError("sigma must be positive")
+        if self.maxiters < 1:
+            raise ValueError("maxiters must be at least 1")
+        if self.context_width < 0:
+            raise ValueError("context_width must be non-negative")
+        if self.guard_width < 0:
+            raise ValueError("guard_width must be non-negative")
+        if self.width_unit not in {"channels", "channel", "Hz", "hz"}:
+            raise ValueError("width_unit must be 'channels' or 'Hz'")
+        if self.combine != "pooled":
+            raise ValueError("combine currently supports only 'pooled'")
+
+
+@dataclass(frozen=True)
+class NoiseStats:
+    """Estimated noise statistics and their selection metadata."""
+
+    mean: float
+    std: float
+    n_samples: int
+    method: str
+    sigma: float | None = None
+    maxiters: int | None = None
+    context_bounds: tuple[int, int] | None = None
+    excluded_bounds: tuple[int, int] | None = None
+    time_bounds: tuple[int, int] | None = None
+    sampled: bool = False
+
+    @property
+    def tchans(self) -> int | None:
+        """Return the number of time bins represented by these stats.
+
+        Returns:
+            Number of time bins when `time_bounds` are known.
+        """
+        if self.time_bounds is None:
+            return None
+        return self.time_bounds[1] - self.time_bounds[0]
+
+    def as_tuple(self) -> tuple[float, float]:
+        """Return `(mean, std)` for compatibility with legacy callers.
+
+        Returns:
+            Mean and standard deviation tuple.
+        """
+        return self.mean, self.std
+
+
+def estimate_array_noise_stats(
+    data: Any,
+    *,
+    config: NoiseEstimationConfig | None = None,
+    context_bounds: tuple[int, int] | None = None,
+    excluded_bounds: tuple[int, int] | None = None,
+    time_bounds: tuple[int, int] | None = None,
+    sampled: bool = False,
+) -> NoiseStats:
+    """Estimate noise statistics from an in-memory array.
+
+    Args:
+        data: Input intensity samples.
+        config: Estimation configuration. Defaults to sigma clipping that
+            matches existing eager `Frame` behavior.
+        context_bounds: Optional frequency context bounds used to select data.
+        excluded_bounds: Optional excluded signal/guard bounds.
+        time_bounds: Optional time bounds used to select data.
+        sampled: Whether the data are a sample rather than exhaustive selection.
+
+    Returns:
+        Structured noise statistics.
+    """
+    resolved = NoiseEstimationConfig() if config is None else config
+    array = np.asarray(data)
+    if array.size == 0:
+        raise ValueError("Cannot estimate noise statistics from an empty array")
+
+    if resolved.method == "sigma_clip":
+        clipped = sigma_clip(array,
+                             sigma=resolved.sigma,
+                             maxiters=resolved.maxiters,
+                             masked=False)
+        samples = np.asarray(clipped)
+        return NoiseStats(mean=float(np.mean(samples)),
+                          std=float(np.std(samples)),
+                          n_samples=int(samples.size),
+                          method=resolved.method,
+                          sigma=resolved.sigma,
+                          maxiters=resolved.maxiters,
+                          context_bounds=context_bounds,
+                          excluded_bounds=excluded_bounds,
+                          time_bounds=time_bounds,
+                          sampled=sampled)
+
+    flattened = array.ravel()
+    median = float(np.median(flattened))
+    mad = float(np.median(np.abs(flattened - median)))
+    return NoiseStats(mean=median,
+                      std=1.4826 * mad,
+                      n_samples=int(flattened.size),
+                      method=resolved.method,
+                      context_bounds=context_bounds,
+                      excluded_bounds=excluded_bounds,
+                      time_bounds=time_bounds,
+                      sampled=sampled)

--- a/setigen/plots.py
+++ b/setigen/plots.py
@@ -27,6 +27,10 @@ def plot_frame(frame: Any,
                minor_ticks: bool=False,
                grid: bool=False,
                swap_axes: bool=False,
+               f_range: tuple[Any, Any] | None = None,
+               t_range: tuple[Any, Any] | None = None,
+               f_index_range: tuple[int, int] | None = None,
+               t_index_range: tuple[int, int] | None = None,
                **kwargs: Any) -> Any:
     """Plot frame spectrogram data.
 
@@ -40,13 +44,23 @@ def plot_frame(frame: Any,
         minor_ticks: Whether to enable minor ticks.
         grid: Whether to draw the major-tick grid.
         swap_axes: Whether to swap frequency and time axes.
+        f_range: Optional frequency range to read before plotting.
+        t_range: Optional time range to read before plotting.
+        f_index_range: Optional half-open frequency index range to plot.
+        t_index_range: Optional half-open time index range to plot.
         **kwargs: Additional `matplotlib.pyplot.imshow()` keyword arguments.
 
     Returns:
         Spectrogram image artist.
     """
+    if any(value is not None for value in (f_range, t_range, f_index_range, t_index_range)):
+        frame = frame.read_frame(f_range=f_range,
+                                 t_range=t_range,
+                                 f_index_range=f_index_range,
+                                 t_index_range=t_index_range)
+
     # Scale intensity if necessary (log vs. linear)
-    data = frame.data
+    data = frame.get_data()
     if db:
         data = utils.db(data)
 

--- a/setigen/slice.py
+++ b/setigen/slice.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ._frame.context import _finalize_derived_frame, _source_bounds_metadata
+
 if TYPE_CHECKING:
     from .frame import Frame
 
@@ -30,10 +32,19 @@ def get_slice(fr: Frame, l: int, r: int) -> Frame:
                         fch1, 
                         fr.ascending,
                         s_data,
-                        metadata=fr.metadata,
                         seed=fr.rng,
                         t_start=fr.t_start,
-                        source_name=fr.source_name,
-                        header=fr.header)
+                        source_name=fr.source_name)
+    _finalize_derived_frame(
+        fr,
+        s_fr,
+        operation="slice",
+        product_type="frame",
+        source_bounds=_source_bounds_metadata(
+            fr,
+            f_index_range=(l, r),
+            t_index_range=(0, fr.tchans),
+        ),
+    )
 
     return s_fr

--- a/setigen/slice.py
+++ b/setigen/slice.py
@@ -31,7 +31,9 @@ def get_slice(fr: Frame, l: int, r: int) -> Frame:
                         fr.ascending,
                         s_data,
                         metadata=fr.metadata,
-                        waterfall=fr.check_waterfall(),
-                        seed=fr.rng)
+                        seed=fr.rng,
+                        t_start=fr.t_start,
+                        source_name=fr.source_name,
+                        header=fr.header)
 
     return s_fr

--- a/setigen/spectrum.py
+++ b/setigen/spectrum.py
@@ -40,7 +40,17 @@ class Spectrum(frame.Frame):
             **kwargs: Additional frame-construction keyword arguments.
         """
         if "tchans" in kwargs:
-            assert kwargs.pop("tchans") == 1
+            tchans = kwargs.pop("tchans")
+            if tchans != 1:
+                raise ValueError("Spectrum requires tchans=1")
+        if data is not None:
+            data = np.asarray(data)
+            if data.ndim == 1:
+                data = data[np.newaxis, :]
+            elif data.ndim != 2 or data.shape[0] != 1:
+                raise ValueError("Spectrum data must be one-dimensional or have shape (1, fchans)")
+            if fchans is None:
+                fchans = data.shape[1]
         frame.Frame.__init__(self,
                              fchans=fchans,
                              tchans=1,

--- a/setigen/split_utils.py
+++ b/setigen/split_utils.py
@@ -8,6 +8,7 @@ from blimpy import Waterfall
 from typing import Iterator
 
 from ._typing import PathLike
+from ._frame.io import _close_waterfall_handles
 
 
 def split_waterfall_generator(
@@ -32,10 +33,13 @@ def split_waterfall_generator(
     """
 
     info_wf = Waterfall(waterfall_fn, load_data=False)
-    fch1 = info_wf.header['fch1']
-    nchans = info_wf.header['nchans']
-    df = info_wf.header['foff']
-    tchans_tot = info_wf.container.selection_shape[0]
+    try:
+        fch1 = info_wf.header['fch1']
+        nchans = info_wf.header['nchans']
+        df = info_wf.header['foff']
+        tchans_tot = info_wf.container.selection_shape[0]
+    finally:
+        _close_waterfall_handles(info_wf)
 
     if f_shift is None:
         f_shift = fchans
@@ -58,7 +62,10 @@ def split_waterfall_generator(
                               t_start=0,
                               t_stop=tchans)
 
-        yield waterfall
+        try:
+            yield waterfall
+        finally:
+            _close_waterfall_handles(waterfall)
 
         f_start += f_shift * df
         f_stop += f_shift * df

--- a/setigen/timeseries.py
+++ b/setigen/timeseries.py
@@ -38,7 +38,17 @@ class TimeSeries(frame.Frame):
             **kwargs: Additional frame-construction keyword arguments.
         """
         if "fchans" in kwargs:
-            assert kwargs.pop("fchans") == 1
+            fchans = kwargs.pop("fchans")
+            if fchans != 1:
+                raise ValueError("TimeSeries requires fchans=1")
+        if data is not None:
+            data = np.asarray(data)
+            if data.ndim == 1:
+                data = data[:, np.newaxis]
+            elif data.ndim != 2 or data.shape[1] != 1:
+                raise ValueError("TimeSeries data must be one-dimensional or have shape (tchans, 1)")
+            if tchans is None:
+                tchans = data.shape[0]
         frame.Frame.__init__(self,
                              fchans=1,
                              tchans=tchans,

--- a/setigen/voltage/_reduction/frame_context.py
+++ b/setigen/voltage/_reduction/frame_context.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from astropy.time import Time
+
+from .writers import _build_filterbank_header
+
+
+def _frame_context_kwargs(input_spec: Any, metadata: Any, *, pol_mode: int) -> dict[str, Any]:
+    """Build `Frame.from_data` context from voltage reduction metadata.
+
+    Args:
+        input_spec: Parsed or synthetic RAW input description.
+        metadata: Derived reduction metadata.
+        pol_mode: Polarization mode for the source product.
+
+    Returns:
+        Keyword arguments that preserve filterbank context on a `Frame`.
+    """
+    header = _build_filterbank_header(input_spec, metadata, pol_mode=pol_mode)
+    source_name = header.get("source_name")
+    if isinstance(source_name, bytes):
+        source_name = source_name.decode()
+
+    kwargs = {"header": header}
+    if source_name is not None:
+        kwargs["source_name"] = source_name
+    if header.get("tstart") is not None:
+        kwargs["t_start"] = Time(header["tstart"], format="mjd").unix
+    return kwargs

--- a/setigen/voltage/reduction.py
+++ b/setigen/voltage/reduction.py
@@ -17,6 +17,7 @@ from ._reduction import (
     _iter_raw_data_blocks,
     _resolve_raw_input,
 )
+from ._reduction.frame_context import _frame_context_kwargs
 from ._reduction.writers import _build_filterbank_header
 
 
@@ -229,4 +230,5 @@ def reduce_raw_to_frame(
             "fftlength": spec.fftlength,
             "integration_factor": spec.integration_factor,
         },
+        **_frame_context_kwargs(input_spec, metadata, pol_mode=spec.pol_mode),
     )

--- a/setigen/voltage/spectrogram.py
+++ b/setigen/voltage/spectrogram.py
@@ -23,6 +23,7 @@ from ._backend.pipeline import (
 )
 from ._backend.recording import _RecordConfig, _resolve_num_blocks
 from ._reduction.channelize import _channelize_block
+from ._reduction.frame_context import _frame_context_kwargs
 from ._reduction.metadata import _ReductionMetadata, _build_reduction_metadata
 from ._reduction.writers import _build_filterbank_header, _create_writer
 from .reduction import PolarizationMode
@@ -124,6 +125,9 @@ class VoltageSpectrogramResult:
                 "integration_factor": self.spec.integration_factor,
                 "source": "voltage_backend",
             },
+            **_frame_context_kwargs(self.input_spec,
+                                    self.metadata,
+                                    pol_mode=self.spec.pol_mode),
         )
 
     def write(

--- a/setigen/waterfall_utils.py
+++ b/setigen/waterfall_utils.py
@@ -5,6 +5,7 @@ import numpy as np
 from blimpy import Waterfall
 
 from ._typing import PathLike
+from ._frame.io import _close_waterfall_handles
 
 
 def max_freq(waterfall: PathLike | Waterfall) -> float:
@@ -44,15 +45,20 @@ def get_data(waterfall: PathLike | Waterfall, db: bool = False) -> np.ndarray:
     Raises:
         ValueError: If the waterfall input type is unsupported.
     """
-    if isinstance(waterfall, (str, PurePath)):
+    owns_waterfall = isinstance(waterfall, (str, PurePath))
+    if owns_waterfall:
         waterfall = Waterfall(waterfall)
     elif not isinstance(waterfall, Waterfall):
         raise ValueError('Invalid data file!')
 
-    if db:
-        return 10 * np.log10(waterfall.data[:, 0, :])
-
-    return waterfall.data[:, 0, :]
+    try:
+        data = waterfall.data[:, 0, :]
+        if db:
+            data = 10 * np.log10(data)
+        return np.array(data, copy=owns_waterfall)
+    finally:
+        if owns_waterfall:
+            _close_waterfall_handles(waterfall)
 
 
 def get_fs(waterfall: PathLike | Waterfall) -> np.ndarray:
@@ -67,16 +73,20 @@ def get_fs(waterfall: PathLike | Waterfall) -> np.ndarray:
     Raises:
         ValueError: If the waterfall input type is unsupported.
     """
-    if isinstance(waterfall, (str, PurePath)):
+    owns_waterfall = isinstance(waterfall, (str, PurePath))
+    if owns_waterfall:
         waterfall = Waterfall(waterfall, load_data=False)
     elif not isinstance(waterfall, Waterfall):
         raise ValueError('Invalid data file!')
 
-    fch1 = waterfall.header['fch1']
-    df = waterfall.header['foff']
-    fchans = waterfall.header['nchans']
-
-    return fch1 + np.arange(fchans) * df
+    try:
+        fch1 = waterfall.header['fch1']
+        df = waterfall.header['foff']
+        fchans = waterfall.header['nchans']
+        return fch1 + np.arange(fchans) * df
+    finally:
+        if owns_waterfall:
+            _close_waterfall_handles(waterfall)
 
 
 def get_ts(waterfall: PathLike | Waterfall) -> np.ndarray:
@@ -91,12 +101,16 @@ def get_ts(waterfall: PathLike | Waterfall) -> np.ndarray:
     Raises:
         ValueError: If the waterfall input type is unsupported.
     """
-    if isinstance(waterfall, (str, PurePath)):
+    owns_waterfall = isinstance(waterfall, (str, PurePath))
+    if owns_waterfall:
         waterfall = Waterfall(waterfall, load_data=False)
     elif not isinstance(waterfall, Waterfall):
         raise ValueError('Invalid data file!')
 
-    tsamp = waterfall.header['tsamp']
-    tchans = waterfall.container.selection_shape[0]
-
-    return np.arange(tchans) * tsamp
+    try:
+        tsamp = waterfall.header['tsamp']
+        tchans = waterfall.container.selection_shape[0]
+        return np.arange(tchans) * tsamp
+    finally:
+        if owns_waterfall:
+            _close_waterfall_handles(waterfall)

--- a/setigen/waterfall_utils.py
+++ b/setigen/waterfall_utils.py
@@ -16,7 +16,7 @@ def max_freq(waterfall: PathLike | Waterfall) -> float:
     Returns:
         Maximum frequency in the data.
     """
-    return np.sort(get_fs(waterfall))[-1]
+    return np.max(get_fs(waterfall))
 
 
 def min_freq(waterfall: PathLike | Waterfall) -> float:
@@ -28,7 +28,7 @@ def min_freq(waterfall: PathLike | Waterfall) -> float:
     Returns:
         Minimum frequency in the data.
     """
-    return np.sort(get_fs(waterfall))[0]
+    return np.min(get_fs(waterfall))
 
 
 def get_data(waterfall: PathLike | Waterfall, db: bool = False) -> np.ndarray:
@@ -76,7 +76,7 @@ def get_fs(waterfall: PathLike | Waterfall) -> np.ndarray:
     df = waterfall.header['foff']
     fchans = waterfall.header['nchans']
 
-    return np.arange(fch1, fch1 + fchans * df, df)
+    return fch1 + np.arange(fchans) * df
 
 
 def get_ts(waterfall: PathLike | Waterfall) -> np.ndarray:
@@ -99,4 +99,4 @@ def get_ts(waterfall: PathLike | Waterfall) -> np.ndarray:
     tsamp = waterfall.header['tsamp']
     tchans = waterfall.container.selection_shape[0]
 
-    return np.arange(0, tchans * tsamp, tsamp)
+    return np.arange(tchans) * tsamp

--- a/tests/test_cadence.py
+++ b/tests/test_cadence.py
@@ -145,6 +145,7 @@ def test_ordered_cadence():
 
 def test_basic_cadence_injection(cadence_setup):
     cad = copy.deepcopy(cadence_setup)
+    original_ts = [frame.ts.copy() for frame in cad]
     cad.apply(lambda fr: fr.add_noise(1))
     cad[0::2].add_signal(stg.constant_path(f_start=cad[0].get_frequency(index=128),
                                            drift_rate=0.1),
@@ -157,6 +158,24 @@ def test_basic_cadence_injection(cadence_setup):
         assert np.max(stg.integrate(cad[i])) > 1.25
     for i in range(1, 6, 2):
         assert np.max(stg.integrate(cad[i])) < 1.11
+    for frame, ts in zip(cad, original_ts):
+        assert_allclose(frame.ts, ts)
+
+
+def test_cadence_add_signal_does_not_mutate_times_on_error(cadence_setup):
+    cad = copy.deepcopy(cadence_setup)
+    original_ts = [frame.ts.copy() for frame in cad]
+
+    def bad_path(t):
+        raise RuntimeError("bad path")
+
+    with pytest.raises(RuntimeError, match="bad path"):
+        cad.add_signal(bad_path,
+                       stg.constant_t_profile(level=1),
+                       stg.box_f_profile(width=cad[0].df))
+
+    for frame, ts in zip(cad, original_ts):
+        assert_allclose(frame.ts, ts)
 
 
 def test_consolidate_preserves_frame_order_and_time_offsets():

--- a/tests/test_file_backed_frame.py
+++ b/tests/test_file_backed_frame.py
@@ -3,7 +3,14 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
+from astropy import units as u
 import setigen as stg
+from setigen._frame import file_mutation
+from setigen._frame.context import _copy_frame_context, _finalize_derived_frame
+from setigen._frame.io import _close_waterfall_handles, _has_live_h5_handle
+from setigen._frame.signal import _get_profile_support_half_width
+from setigen._spectrogram import copy_spectrogram, open_spectrogram
+from setigen._spectrogram.fil import _HEADER_KEYWORD_TYPES, _dtype_from_nbits, _read_keyword
 
 
 def _write_frame(frame, path):
@@ -271,3 +278,333 @@ def test_file_backed_spectrum_and_timeseries_match_eager(tmp_path, suffix):
     assert_allclose(backed_timeseries.data, eager_timeseries.data)
     assert backed_spectrum.metadata["derived"]["source_bounds"]["frequency_index_range"] == (4, 20)
     assert backed_timeseries.metadata["derived"]["source_bounds"]["time_index_range"] == (2, 7)
+
+
+def test_file_backed_frame_data_and_noise_guardrails(tmp_path):
+    source_path = tmp_path / "source.h5"
+    frame = stg.Frame(tchans=4, fchans=8, df=2, dt=1, fch1=6e9)
+    frame.data[:] = np.arange(np.prod(frame.shape)).reshape(frame.shape)
+    frame.save_hdf5(source_path)
+
+    with pytest.raises(ValueError, match="mode='r'"):
+        stg.Frame.open(source_path, mode="w")
+
+    with stg.Frame.open_copy(source_path, tmp_path / "copy.h5") as backed:
+        assert_allclose(backed.copy().data, frame.data)
+        assert_allclose(backed.data, frame.data)
+
+        backed.data = None
+        assert backed._data is None
+        with pytest.raises(ValueError, match="Data shape"):
+            backed.data = np.zeros((1, 1))
+
+        replacement = np.full(frame.shape, 5, dtype=np.float32)
+        backed.data = replacement
+        assert_allclose(backed.data, replacement)
+
+        backed._update_noise_frame_stats()
+        assert backed.noise_stats is None
+        with pytest.raises(NotImplementedError, match="add_noise"):
+            backed.add_noise(1)
+        with pytest.raises(NotImplementedError, match="add_noise_from_obs"):
+            backed.add_noise_from_obs()
+
+
+def test_frame_noise_bounds_and_range_edges():
+    frame = stg.Frame(tchans=4, fchans=16, df=2, dt=1, fch1=6e9, ascending=True)
+    frame.data[:] = np.arange(np.prod(frame.shape)).reshape(frame.shape)
+
+    stats = frame.estimate_noise_stats(
+        bounding_f_range=(frame.get_frequency(-50), frame.get_frequency(-40)),
+        config=stg.NoiseEstimationConfig(context_width=2, guard_width=0),
+    )
+    assert stats.context_bounds == (0, 3)
+
+    stats = frame.estimate_noise_stats(
+        path=frame.get_frequency(5),
+        config=stg.NoiseEstimationConfig(context_width=2 * frame.df,
+                                         guard_width=0,
+                                         width_unit="Hz"),
+    )
+    assert stats.context_bounds == (3, 8)
+
+    with pytest.raises(ValueError, match="requires path and f_profile"):
+        frame.estimate_noise_stats(auto_bounding=True)
+    with pytest.raises(ValueError, match="empty"):
+        frame.estimate_noise_stats(f_index_range=(2, 2))
+    with pytest.raises(ValueError, match="guard removed all"):
+        frame.estimate_noise_stats(
+            bounding_f_range=(frame.get_frequency(5), frame.get_frequency(6)),
+            config=stg.NoiseEstimationConfig(context_width=0, guard_width=10),
+        )
+
+    sub = frame.read_frame(f_range=(frame.frequency_edges[2] * u.Hz,
+                                    frame.frequency_edges[5] * u.Hz),
+                           t_range=(1 * u.s, 3 * u.s))
+    assert_allclose(sub.data, frame.data[1:3, 2:5])
+    assert sub.fch1 == frame.fs[2]
+
+    with pytest.raises(ValueError, match="empty"):
+        frame.read_frame(f_index_range=(3, 3))
+
+
+def test_frame_misc_edge_contracts():
+    frame = stg.Frame(tchans=4, fchans=8, df=1, dt=2, fch1=6e9)
+    assert frame.get_intensity(10, noise_stats=(0, 2)) == pytest.approx(10)
+    assert frame.get_snr(10, noise_stats=(0, 2)) == pytest.approx(10)
+    assert frame.get_drift_rate(0, 2, reference="centers") == pytest.approx(1 / 3)
+    with pytest.raises(ValueError, match="at least two"):
+        stg.Frame(tchans=1, fchans=8).get_drift_rate(0, 1, reference="centers")
+    with pytest.raises(ValueError, match="reference"):
+        frame.get_drift_rate(0, 1, reference="bad")
+    assert_allclose(frame.integrate(), np.zeros(frame.fchans))
+
+    class BadWaterfall:
+        def __deepcopy__(self, memo):
+            raise RuntimeError("no copy")
+
+    frame.waterfall = BadWaterfall()
+    assert frame.copy().waterfall is None
+
+
+def test_integration_edge_contracts(tmp_path):
+    data = np.arange(12, dtype=np.float32).reshape(3, 4)
+    array_like = data.tolist()
+    assert_allclose(stg.integrate(array_like, axis="frequency", mode="sum"), np.sum(data, axis=1))
+    assert_allclose(stg.integrate(array_like, axis=1, mode="mean"), np.mean(data, axis=1))
+
+    with pytest.raises(ValueError, match="Frame-like"):
+        stg.integrate(array_like, f_index_range=(0, 1))
+    with pytest.raises(TypeError, match="Frame-like"):
+        stg.integrate(array_like, as_frame=True)
+
+    frame = stg.Frame(tchans=3, fchans=4, df=1, dt=1, fch1=6e9, data=data)
+    with pytest.raises(ValueError, match="empty"):
+        stg.integrate(frame, f_index_range=(2, 2))
+    assert_allclose(stg.integrate(frame, axis="frequency"), np.mean(data, axis=1))
+
+    source_path = tmp_path / "integrate_source.h5"
+    frame.save_hdf5(source_path)
+    with stg.Frame.open(source_path) as backed:
+        assert_allclose(backed.spectrum(mode="mean").data, np.mean(data, axis=0, keepdims=True))
+        with pytest.raises(ValueError, match="max_chunk_bytes"):
+            backed.spectrum(max_chunk_bytes=0)
+
+
+def test_signal_support_metadata_and_callable_paths():
+    assert _get_profile_support_half_width(stg.gaussian_f_profile(width=10), None) is None
+    assert _get_profile_support_half_width(stg.multiple_gaussian_f_profile(width=10), 1e-3) > 100
+    assert _get_profile_support_half_width(stg.lorentzian_f_profile(width=10), 1e-3) > 0
+    assert _get_profile_support_half_width(stg.voigt_f_profile(10, 10), 1e-3) is None
+
+    frame = stg.Frame(tchans=4, fchans=64, df=1, dt=1, fch1=6e9 + 32)
+    frame.add_signal(path=lambda ts: 6e9,
+                     t_profile=1,
+                     f_profile=stg.gaussian_f_profile(width=3),
+                     auto_bounding=True)
+    assert np.max(frame.data) > 0
+
+    frame.zero_data()
+    frame.add_signal(path=lambda ts: 6e9,
+                     t_profile=1,
+                     f_profile=stg.box_f_profile(width=3),
+                     integrate_path=True,
+                     auto_bounding=True)
+    assert np.max(frame.data) > 0
+
+
+def test_file_mutation_private_edge_helpers(tmp_path):
+    frame = stg.Frame(tchans=4, fchans=8, df=1, dt=1, fch1=6e9, ascending=True)
+    chunk = file_mutation._ChunkFrameView(
+        frame,
+        t_start_index=1,
+        tchans=2,
+        f_start_index=2,
+        f_stop_index=6,
+        data=np.zeros((2, 4)),
+    )
+    assert chunk.get_index(6e9 + 3) == 1
+    assert file_mutation._slice_time_input(5, t_start=0, t_stop=1, full_tchans=4) == 5
+    mismatched = np.arange(3)
+    assert file_mutation._slice_time_input(mismatched,
+                                           t_start=0,
+                                           t_stop=1,
+                                           full_tchans=4) is mismatched
+    assert file_mutation._evaluate_t_profile_values(frame, 3) == 3
+    assert_allclose(
+        file_mutation._evaluate_t_profile_values(frame,
+                                                 lambda ts: 2,
+                                                 integrate_t_profile=True,
+                                                 t_subsamples=2),
+        np.full(frame.tchans, 2),
+    )
+    assert_allclose(file_mutation._evaluate_t_profile_values(frame, lambda ts: 4),
+                    np.full(frame.tchans, 4))
+    assert file_mutation._choose_chunk_tchans(frame,
+                                              affected_fchans=8,
+                                              max_chunk_bytes=None,
+                                              chunk_tchans=2) == 2
+    with pytest.raises(ValueError, match="chunk_tchans"):
+        file_mutation._choose_chunk_tchans(frame,
+                                           affected_fchans=8,
+                                           max_chunk_bytes=None,
+                                           chunk_tchans=0)
+    with pytest.raises(ValueError, match="max_chunk_bytes"):
+        file_mutation._choose_chunk_tchans(frame,
+                                           affected_fchans=8,
+                                           max_chunk_bytes=0,
+                                           chunk_tchans=None)
+
+    source_path = tmp_path / "source.h5"
+    frame.save_hdf5(source_path)
+    with stg.Frame.open_copy(source_path, tmp_path / "out.h5") as backed:
+        with pytest.raises(ValueError, match="smearing_subsamples"):
+            backed.add_signal(path=stg.constant_path(frame.get_frequency(4), drift_rate=0),
+                              t_profile=1,
+                              f_profile=stg.box_f_profile(width=frame.df),
+                              doppler_smearing=True,
+                              smearing_subsamples=0)
+        empty = backed.add_signal(path=stg.constant_path(frame.get_frequency(4), drift_rate=0),
+                                  t_profile=1,
+                                  f_profile=stg.box_f_profile(width=frame.df),
+                                  bounding_f_range=(frame.get_frequency(-10),
+                                                    frame.get_frequency(-9)))
+        assert empty.time_chunks == 0
+
+        result = backed.add_signal(path=lambda ts: frame.get_frequency(4),
+                                   t_profile=1,
+                                   f_profile=stg.box_f_profile(width=frame.df),
+                                   bounding_f_range=(frame.get_frequency(3),
+                                                     frame.get_frequency(5)))
+        assert result.time_chunks > 0
+
+
+def test_private_context_and_io_helpers():
+    class SourceNoParams:
+        metadata = {"science": "kept", "file_backed": True}
+        header = None
+        shape = (1, 1)
+
+    class Target:
+        def __init__(self):
+            self.metadata = {}
+            self.header = {"source_name": "T",
+                           "tsamp": 1,
+                           "tstart": 1,
+                           "nchans": 1,
+                           "nifs": 1,
+                           "fch1": 1,
+                           "foff": 1}
+            self.source_name = "Target"
+            self.dt = 2
+            self.t_start = 0
+            self.fchans = 1
+            self.fch1 = 6e9
+            self.df = 1
+            self.ascending = True
+
+        def add_metadata(self, metadata):
+            self.metadata.update(metadata)
+
+    target = Target()
+    _finalize_derived_frame(SourceNoParams(), target, operation="unit")
+    assert target.metadata["science"] == "kept"
+    assert target.metadata["derived"]["operation"] == "unit"
+
+    copied = Target()
+    _copy_frame_context(SourceNoParams(), copied)
+    assert copied.metadata["science"] == "kept"
+
+    class BadClose:
+        def close(self):
+            raise RuntimeError("close failed")
+
+    class BadId:
+        @property
+        def valid(self):
+            raise RuntimeError("invalid")
+
+    class Container:
+        h5 = BadClose()
+
+    class Waterfall:
+        container = Container()
+
+    _close_waterfall_handles(Waterfall())
+    Waterfall.container.h5.id = BadId()
+    assert _has_live_h5_handle(Waterfall()) is True
+
+
+def test_spectrogram_backend_edge_contracts(tmp_path):
+    with pytest.raises(ValueError, match="Unsupported"):
+        open_spectrogram(tmp_path / "bad.txt")
+
+    source = tmp_path / "source.h5"
+    stg.Frame(tchans=2, fchans=4).save_hdf5(source)
+    copied = tmp_path / "copied.h5"
+    copy_spectrogram(source, copied)
+    with pytest.raises(FileExistsError):
+        copy_spectrogram(source, copied)
+
+    with open_spectrogram(source) as backend:
+        assert backend.shape == (2, 4)
+    backend = open_spectrogram(source)
+    backend.__exit__(None, None, None)
+
+    with open_spectrogram(source) as backend:
+        with pytest.raises(IndexError, match="frequency"):
+            backend.read_region(0, 1, -1, 1)
+        with pytest.raises(IndexError, match="time"):
+            backend.read_region(-1, 1, 0, 1)
+        with pytest.raises(OSError, match="read-only"):
+            backend.write_region(0, 0, np.zeros((1, 1)))
+
+    with open_spectrogram(source, mode="r+") as backend:
+        with pytest.raises(ValueError, match="two-dimensional"):
+            backend.write_region(0, 0, np.zeros(4))
+        with pytest.raises(IndexError, match="time"):
+            backend.write_region(-1, 0, np.zeros((1, 1)))
+        state = backend.__getstate__()
+        assert state["_h5"] is None
+        assert state["_dataset"] is None
+
+    fil_source = tmp_path / "source.fil"
+    stg.Frame(tchans=2, fchans=4).save_fil(fil_source)
+    with open_spectrogram(fil_source) as backend:
+        with pytest.raises(IndexError, match="frequency"):
+            backend.read_region(0, 1, -1, 1)
+        with pytest.raises(IndexError, match="time"):
+            backend.read_region(-1, 1, 0, 1)
+        with pytest.raises(OSError, match="read-only"):
+            backend.write_region(0, 0, np.zeros((1, 1)))
+
+    with open_spectrogram(fil_source, mode="r+") as backend:
+        with pytest.raises(ValueError, match="two-dimensional"):
+            backend.write_region(0, 0, np.zeros(4))
+        with pytest.raises(IndexError, match="time"):
+            backend.write_region(-1, 0, np.zeros((1, 1)))
+        with pytest.raises(IndexError, match="frequency"):
+            backend.write_region(0, 0, np.zeros((1, 5)))
+        backend._disk_frequency_slice = lambda f_start, f_stop: (0, 1, False)
+        with pytest.raises(ValueError, match="width"):
+            backend.write_region(0, 0, np.zeros((1, 2)))
+
+    bad = tmp_path / "bad.fil"
+    bad.write_bytes((10).to_bytes(4, "little") + b"HEADER_END")
+    with pytest.raises(RuntimeError, match="valid"):
+        open_spectrogram(bad)
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        _dtype_from_nbits(4)
+
+    import io
+    with pytest.raises(RuntimeError, match="Unexpected end"):
+        _read_keyword(io.BytesIO(b""))
+    old = _HEADER_KEYWORD_TYPES["machine_id"]
+    _HEADER_KEYWORD_TYPES["machine_id"] = "bad"
+    try:
+        keyword = len("machine_id").to_bytes(4, "little") + b"machine_id"
+        with pytest.raises(RuntimeError, match="Unsupported"):
+            _read_keyword(io.BytesIO(keyword))
+    finally:
+        _HEADER_KEYWORD_TYPES["machine_id"] = old

--- a/tests/test_file_backed_frame.py
+++ b/tests/test_file_backed_frame.py
@@ -1,0 +1,273 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+import setigen as stg
+
+
+def _write_frame(frame, path):
+    if path.suffix == ".h5":
+        frame.save_hdf5(path)
+    else:
+        frame.save_fil(path)
+
+
+def _signal_kwargs(frame):
+    return dict(
+        path=stg.constant_path(frame.get_frequency(frame.fchans // 2), drift_rate=0),
+        t_profile=stg.constant_t_profile(3),
+        f_profile=stg.box_f_profile(width=4 * frame.df),
+        auto_bounding=True,
+    )
+
+
+def _contract_signal_kwargs(frame, case):
+    if case == "drifted_integrated_gaussian":
+        return dict(
+            path=stg.constant_path(
+                frame.get_frequency(frame.fchans // 2 - 6),
+                drift_rate=0.35 * frame.unit_drift_rate,
+            ),
+            t_profile=stg.sine_t_profile(
+                period=4 * frame.dt,
+                amplitude=0.4,
+                level=2.0,
+            ),
+            f_profile=stg.gaussian_f_profile(width=5 * frame.df),
+            bp_profile=stg.constant_bp_profile(level=1),
+            integrate_path=True,
+            integrate_t_profile=True,
+            integrate_f_profile=True,
+            t_subsamples=4,
+            f_subsamples=4,
+            auto_bounding=True,
+            truncate_below=1e-3,
+        )
+    if case == "doppler_smeared_sinc2":
+        return dict(
+            path=stg.constant_path(
+                frame.get_frequency(frame.fchans // 2),
+                drift_rate=1.5 * frame.unit_drift_rate,
+            ),
+            t_profile=stg.constant_t_profile(level=1.5),
+            f_profile=stg.sinc2_f_profile(width=4 * frame.df),
+            bp_profile=stg.constant_bp_profile(level=1),
+            doppler_smearing=True,
+            smearing_subsamples=5,
+            auto_bounding=True,
+        )
+    raise ValueError(f"Unknown signal contract case {case}")
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".fil"])
+def test_file_backed_open_copy_add_signal_matches_eager(tmp_path, suffix):
+    source_path = tmp_path / f"source{suffix}"
+    output_path = tmp_path / f"injected{suffix}"
+
+    source_frame = stg.Frame(tchans=8,
+                             fchans=64,
+                             df=2,
+                             dt=1,
+                             fch1=1062,
+                             ascending=False,
+                             source_name="Target")
+    source_frame.data[:] = np.arange(np.prod(source_frame.shape),
+                                     dtype=np.float32).reshape(source_frame.shape)
+    _write_frame(source_frame, source_path)
+
+    eager = stg.Frame(waterfall=source_path)
+    kwargs = _signal_kwargs(eager)
+    eager.add_signal(**kwargs)
+
+    with stg.Frame.open_copy(source_path,
+                             output_path,
+                             max_chunk_bytes=256) as frame:
+        result = frame.add_signal(**kwargs)
+        assert frame.is_file_backed
+        assert result.time_chunks > 1
+
+        region = frame.read_frame(f_index_range=(24, 36),
+                                  t_index_range=(0, frame.tchans))
+        assert_allclose(region.data, eager.data[:, 24:36])
+
+        artist = frame.plot(f_index_range=(24, 36),
+                            t_index_range=(0, frame.tchans),
+                            db=False,
+                            colorbar=False)
+        assert artist is not None
+        plt.close()
+
+    loaded_output = stg.Frame(waterfall=output_path)
+    assert_allclose(loaded_output.data, eager.data)
+
+    loaded_source = stg.Frame(waterfall=source_path)
+    assert_allclose(loaded_source.data, source_frame.data)
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".fil"])
+@pytest.mark.parametrize("ascending", [False, True])
+@pytest.mark.parametrize("case", ["drifted_integrated_gaussian", "doppler_smeared_sinc2"])
+def test_file_backed_add_signal_contract_matches_eager_for_common_options(
+    tmp_path,
+    suffix,
+    ascending,
+    case,
+):
+    source_path = tmp_path / f"source_{ascending}_{case}{suffix}"
+    output_path = tmp_path / f"injected_{ascending}_{case}{suffix}"
+    source_frame = stg.Frame(tchans=8,
+                             fchans=96,
+                             df=1,
+                             dt=1,
+                             fch1=6e9 + (0 if ascending else 95),
+                             ascending=ascending,
+                             source_name="Target")
+    source_frame.data[:] = np.arange(np.prod(source_frame.shape),
+                                     dtype=np.float32).reshape(source_frame.shape) / 100
+    _write_frame(source_frame, source_path)
+
+    eager = stg.Frame(waterfall=source_path)
+    kwargs = _contract_signal_kwargs(eager, case)
+    eager.add_signal(**kwargs)
+
+    with stg.Frame.open_copy(source_path,
+                             output_path,
+                             max_chunk_bytes=256) as backed:
+        result = backed.add_signal(**kwargs)
+        assert result.time_chunks > 1
+
+    loaded_output = stg.Frame(waterfall=output_path)
+    loaded_source = stg.Frame(waterfall=source_path)
+    assert_allclose(loaded_output.data, eager.data, rtol=1e-6, atol=1e-6)
+    assert_allclose(loaded_source.data, source_frame.data)
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".fil"])
+@pytest.mark.parametrize("ascending", [False, True])
+@pytest.mark.parametrize("channel_index", [0, 1, 37, 94, 95])
+def test_file_backed_add_signal_preserves_exact_channel_index(
+    tmp_path,
+    suffix,
+    ascending,
+    channel_index,
+):
+    source_path = tmp_path / f"source_{ascending}_{channel_index}{suffix}"
+    output_path = tmp_path / f"injected_{ascending}_{channel_index}{suffix}"
+    source_frame = stg.Frame(tchans=5,
+                             fchans=96,
+                             df=1,
+                             dt=1,
+                             fch1=6e9 + (0 if ascending else 95),
+                             ascending=ascending,
+                             source_name="Target")
+    _write_frame(source_frame, source_path)
+
+    eager = stg.Frame(waterfall=source_path)
+    kwargs = dict(
+        path=stg.constant_path(eager.get_frequency(channel_index), drift_rate=0),
+        t_profile=stg.constant_t_profile(level=7),
+        f_profile=stg.box_f_profile(width=eager.df),
+        bp_profile=stg.constant_bp_profile(level=1),
+        auto_bounding=True,
+    )
+    eager.add_signal(**kwargs)
+
+    with stg.Frame.open_copy(source_path,
+                             output_path,
+                             max_chunk_bytes=64) as backed:
+        result = backed.add_signal(**kwargs)
+        assert result.time_chunks > 1
+
+    loaded_output = stg.Frame(waterfall=output_path)
+    loaded_source = stg.Frame(waterfall=source_path)
+    expected_delta = np.zeros(source_frame.shape)
+    expected_delta[:, channel_index] = 7
+    assert_allclose(loaded_output.data, eager.data, rtol=1e-6, atol=1e-6)
+    assert_allclose(loaded_output.data - loaded_source.data, expected_delta)
+    assert_allclose(loaded_source.data, source_frame.data)
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".fil"])
+def test_file_backed_read_only_frames_do_not_mutate(tmp_path, suffix):
+    source_path = tmp_path / f"source{suffix}"
+    frame = stg.Frame(tchans=4, fchans=16, df=1, dt=1, fch1=1015)
+    _write_frame(frame, source_path)
+
+    with stg.Frame.open(source_path) as backed:
+        assert backed.is_file_backed
+        with pytest.raises(OSError, match="read-only"):
+            backed.add_signal(**_signal_kwargs(backed))
+
+
+def test_file_backed_direct_write_requires_explicit_guard(tmp_path):
+    source_path = tmp_path / "source.h5"
+    stg.Frame(tchans=4, fchans=16).save_hdf5(source_path)
+
+    with pytest.raises(ValueError, match="allow_inplace"):
+        stg.Frame.open(source_path, mode="r+")
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".fil"])
+def test_file_backed_noise_stats_use_local_context(tmp_path, suffix):
+    source_path = tmp_path / f"source{suffix}"
+    frame = stg.Frame(tchans=8, fchans=64, df=1, dt=1, fch1=1063)
+    frame.data[:] = 1000
+    local_pattern = np.array([9, 11] * 8, dtype=np.float32)
+    frame.data[:, 24:40] = local_pattern
+    _write_frame(frame, source_path)
+
+    with stg.Frame.open(source_path) as backed:
+        with pytest.raises(ValueError, match="explicit path"):
+            backed.estimate_noise_stats()
+
+        stats = backed.estimate_noise_stats(
+            bounding_f_range=(backed.get_frequency(30),
+                              backed.get_frequency(34)),
+            t_index_range=(0, backed.tchans),
+            config=stg.NoiseEstimationConfig(context_width=6,
+                                             guard_width=1),
+        )
+
+    assert stats.mean == pytest.approx(10)
+    assert stats.std == pytest.approx(1)
+    assert stats.context_bounds == (24, 40)
+    assert stats.excluded_bounds == (29, 35)
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".fil"])
+def test_file_backed_spectrum_and_timeseries_match_eager(tmp_path, suffix):
+    source_path = tmp_path / f"source{suffix}"
+    source_frame = stg.Frame(tchans=8,
+                             fchans=32,
+                             df=2,
+                             dt=1,
+                             fch1=1062,
+                             ascending=False,
+                             source_name="Target")
+    source_frame.data[:] = np.arange(np.prod(source_frame.shape),
+                                     dtype=np.float32).reshape(source_frame.shape)
+    _write_frame(source_frame, source_path)
+
+    eager = stg.Frame(waterfall=source_path)
+    eager_spectrum = eager.spectrum(mode="sum",
+                                    f_index_range=(4, 20),
+                                    t_index_range=(2, 7))
+    eager_timeseries = eager.timeseries(mode="mean",
+                                        f_index_range=(4, 20),
+                                        t_index_range=(2, 7))
+
+    with stg.Frame.open(source_path, max_chunk_bytes=64) as backed:
+        backed_spectrum = backed.spectrum(mode="sum",
+                                          f_index_range=(4, 20),
+                                          t_index_range=(2, 7),
+                                          max_chunk_bytes=64)
+        backed_timeseries = backed.timeseries(mode="mean",
+                                              f_index_range=(4, 20),
+                                              t_index_range=(2, 7),
+                                              max_chunk_bytes=64)
+
+    assert_allclose(backed_spectrum.data, eager_spectrum.data)
+    assert_allclose(backed_timeseries.data, eager_timeseries.data)
+    assert backed_spectrum.metadata["derived"]["source_bounds"]["frequency_index_range"] == (4, 20)
+    assert backed_timeseries.metadata["derived"]["source_bounds"]["time_index_range"] == (2, 7)

--- a/tests/test_frame_creation.py
+++ b/tests/test_frame_creation.py
@@ -63,6 +63,42 @@ def test_from_backend_params():
     assert frame.tchans == 128 
 
 
+def test_frame_params_from_backend():
+    params = stg.frame_params_from_backend(obs_length=600,
+                                           sample_rate=3e9,
+                                           num_branches=1024,
+                                           fftlength=524288,
+                                           int_factor=26)
+
+    assert params["tchans"] == 128
+    assert params["df"] == pytest.approx(5.587935447692871)
+    assert params["dt"] == pytest.approx(4.652881237333333)
+
+    frame = stg.Frame(fchans=256,
+                      fch1=6e9,
+                      ascending=False,
+                      **params)
+    assert frame.fchans == 256
+    assert frame.tchans == 128
+    assert frame.df == pytest.approx(params["df"])
+    assert frame.dt == pytest.approx(params["dt"])
+
+
+def test_params_from_backend_deprecated():
+    with pytest.warns(DeprecationWarning, match="frame_params_from_backend"):
+        deprecated_params = stg.params_from_backend(obs_length=600,
+                                                   sample_rate=3e9,
+                                                   num_branches=1024,
+                                                   fftlength=524288,
+                                                   int_factor=26)
+
+    assert deprecated_params == stg.frame_params_from_backend(obs_length=600,
+                                                             sample_rate=3e9,
+                                                             num_branches=1024,
+                                                             fftlength=524288,
+                                                             int_factor=26)
+
+
 def test_init_precedence_rules():
     data = np.ones((3, 4))
     frame = stg.Frame(fchans=99,
@@ -140,14 +176,112 @@ def test_integrated_frames_preserve_observational_context():
     spectrum = stg.spectrum(frame, mode="sum")
     timeseries = stg.timeseries(frame, mode="sum")
 
-    for derived in [spectrum, timeseries]:
+    for derived, product_type, collapsed_axis in [
+        (spectrum, "spectrum", "time"),
+        (timeseries, "timeseries", "frequency"),
+    ]:
         assert derived.t_start == frame.t_start
         assert derived.source_name == frame.source_name
-        assert derived.header == frame.header
+        assert derived.header["rawdatafile"] == frame.header["rawdatafile"]
+        assert derived.header["source_name"] == frame.source_name
+        assert derived.header["nchans"] == derived.fchans
+        assert derived.header["tsamp"] == derived.dt
         assert derived.header is not frame.header
         assert derived.metadata["drift_rate"] == frame.metadata["drift_rate"]
         assert derived.metadata["fchans"] == derived.fchans
         assert derived.metadata["tchans"] == derived.tchans
+        assert derived.metadata["derived"]["operation"] == "integrate"
+        assert derived.metadata["derived"]["product_type"] == product_type
+        assert derived.metadata["derived"]["collapsed_axis"] == collapsed_axis
+        assert derived.metadata["derived"]["reducer"] == "sum"
+        assert derived.metadata["derived"]["source_shape"] == frame.shape
+
+
+def test_sliced_and_dedrifted_frames_preserve_observational_context():
+    frame = stg.Frame(shape=(4, 8),
+                      t_start=123456,
+                      source_name="Target",
+                      data=np.ones((4, 8)))
+    frame.header = {"rawdatafile": "original.raw", "source_name": "Target"}
+    frame.add_metadata({"drift_rate": 0})
+
+    sliced = frame.get_slice(2, 6)
+    dedrifted = stg.dedrift(frame)
+
+    for derived, operation in [(sliced, "slice"), (dedrifted, "dedrift")]:
+        assert derived.t_start == frame.t_start
+        assert derived.source_name == frame.source_name
+        assert derived.header["rawdatafile"] == frame.header["rawdatafile"]
+        assert derived.header["source_name"] == frame.source_name
+        assert derived.header["nchans"] == derived.fchans
+        assert derived.header["tsamp"] == derived.dt
+        assert derived.header is not frame.header
+        assert derived.metadata["drift_rate"] == frame.metadata["drift_rate"]
+        assert derived.metadata["fchans"] == derived.fchans
+        assert derived.metadata["tchans"] == derived.tchans
+        assert derived.metadata["derived"]["operation"] == operation
+        assert derived.metadata["derived"]["source_shape"] == frame.shape
+
+
+def test_spectrum_and_timeseries_accept_1d_data():
+    spectrum = stg.Spectrum(df=2, dt=3, fch1=100, data=np.arange(4))
+    assert spectrum.shape == (1, 4)
+    assert_allclose(spectrum.array(), np.arange(4))
+
+    timeseries = stg.TimeSeries(df=8, dt=3, fch1=104, data=np.arange(5))
+    assert timeseries.shape == (5, 1)
+    assert_allclose(timeseries.array(), np.arange(5))
+
+    with pytest.raises(ValueError, match="Spectrum data"):
+        stg.Spectrum(data=np.ones((2, 4)))
+
+    with pytest.raises(ValueError, match="TimeSeries data"):
+        stg.TimeSeries(data=np.ones((5, 2)))
+
+    with pytest.raises(ValueError, match="tchans=1"):
+        stg.Spectrum(tchans=2, data=np.arange(4))
+
+    with pytest.raises(ValueError, match="fchans=1"):
+        stg.TimeSeries(fchans=2, data=np.arange(5))
+
+
+def test_region_integrated_products_have_metadata():
+    data = np.arange(24).reshape(4, 6)
+    frame = stg.Frame(df=2,
+                      dt=5,
+                      fch1=100,
+                      ascending=True,
+                      data=data,
+                      t_start=1000,
+                      source_name="Target")
+    frame.header = {"rawdatafile": "source.raw"}
+    spectrum = frame.spectrum(mode="sum",
+                              f_index_range=(1, 5),
+                              t_index_range=(1, 3))
+    timeseries = frame.timeseries(mode="mean",
+                                  f_index_range=(1, 5),
+                                  t_index_range=(1, 3))
+
+    assert_allclose(spectrum.data, np.sum(data[1:3, 1:5], axis=0, keepdims=True))
+    assert spectrum.shape == (1, 4)
+    assert spectrum.fch1 == frame.fs[1]
+    assert spectrum.dt == 10
+    assert spectrum.t_start == 1005
+    assert spectrum.header["nchans"] == 4
+
+    assert_allclose(timeseries.data, np.mean(data[1:3, 1:5], axis=1, keepdims=True))
+    assert timeseries.shape == (2, 1)
+    assert timeseries.df == 8
+    assert timeseries.fch1 == pytest.approx((frame.frequency_edges[1] + frame.frequency_edges[5]) / 2)
+    assert timeseries.t_start == 1005
+    assert timeseries.header["nchans"] == 1
+
+    for derived, product_type in [(spectrum, "spectrum"), (timeseries, "timeseries")]:
+        metadata = derived.metadata["derived"]
+        assert metadata["operation"] == "integrate"
+        assert metadata["product_type"] == product_type
+        assert metadata["source_bounds"]["frequency_index_range"] == (1, 5)
+        assert metadata["source_bounds"]["time_index_range"] == (1, 3)
 
 
 def test_h5_ingestion_does_not_retain_live_waterfall(tmp_path):
@@ -184,3 +318,17 @@ def test_waterfall_object_ingestion_does_not_mutate_source_h5(tmp_path):
         assert hasattr(waterfall.container, "h5")
     finally:
         waterfall.container.h5.close()
+
+
+def test_save_hdf5_decodes_header_after_write_error(monkeypatch, tmp_path):
+    frame = stg.Frame(shape=(4, 8), source_name="Target")
+
+    def raise_write_error(self, filename):
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr(bl.Waterfall, "write_to_hdf5", raise_write_error)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        frame.save_hdf5(tmp_path / "frame.h5")
+
+    assert isinstance(frame.waterfall.header["source_name"], str)

--- a/tests/test_frame_creation.py
+++ b/tests/test_frame_creation.py
@@ -129,6 +129,27 @@ def test_axis_semantics():
     assert frame.get_drift_rate(0, 3, reference="centers") == pytest.approx(7.5)
 
 
+def test_integrated_frames_preserve_observational_context():
+    frame = stg.Frame(shape=(4, 8),
+                      t_start=123456,
+                      source_name="Target",
+                      data=np.ones((4, 8)))
+    frame.header = {"rawdatafile": "original.raw", "source_name": "Target"}
+    frame.add_metadata({"drift_rate": 1.25})
+
+    spectrum = stg.spectrum(frame, mode="sum")
+    timeseries = stg.timeseries(frame, mode="sum")
+
+    for derived in [spectrum, timeseries]:
+        assert derived.t_start == frame.t_start
+        assert derived.source_name == frame.source_name
+        assert derived.header == frame.header
+        assert derived.header is not frame.header
+        assert derived.metadata["drift_rate"] == frame.metadata["drift_rate"]
+        assert derived.metadata["fchans"] == derived.fchans
+        assert derived.metadata["tchans"] == derived.tchans
+
+
 def test_h5_ingestion_does_not_retain_live_waterfall(tmp_path):
     frame = stg.Frame(shape=(4, 8), seed=0)
     h5_path = tmp_path / "frame.h5"

--- a/tests/test_frame_creation.py
+++ b/tests/test_frame_creation.py
@@ -1,18 +1,23 @@
 import pytest
+import pickle
 
 import numpy as np
 from numpy.testing import assert_allclose
 import setigen as stg
 from astropy.time import Time
 from pathlib import Path
+import blimpy as bl
 
 
 def test_frame_copy_mjd():
     frame = stg.Frame(shape=(16, 256), mjd=60000)
     assert frame.t_start == pytest.approx(1677283200.0)
+    assert frame.waterfall is None
 
     frame.add_noise_from_obs()
     frame2 = frame.copy()
+    assert frame.waterfall is None
+    assert frame2.waterfall is None
     assert_allclose(frame.data, frame2.data)
 
 
@@ -108,3 +113,53 @@ def test_waterfall_path_selection_kwargs():
                              f_stop=subset_stop)
 
     assert subset_frame.fchans < full_frame.fchans
+
+
+def test_axis_semantics():
+    frame = stg.Frame(tchans=3, fchans=4, dt=2, df=10, fch1=40)
+
+    assert_allclose(frame.frequency_centers, frame.fs)
+    assert_allclose(frame.frequency_edges, np.array([5, 15, 25, 35, 45]))
+    assert_allclose(frame.time_starts, np.array([0, 2, 4]))
+    assert_allclose(frame.time_centers, np.array([1, 3, 5]))
+    assert_allclose(frame.time_edges, np.array([0, 2, 4, 6]))
+    assert_allclose(frame.ts_ext, frame.time_edges)
+
+    assert frame.get_drift_rate(0, 3) == pytest.approx(5)
+    assert frame.get_drift_rate(0, 3, reference="centers") == pytest.approx(7.5)
+
+
+def test_h5_ingestion_does_not_retain_live_waterfall(tmp_path):
+    frame = stg.Frame(shape=(4, 8), seed=0)
+    h5_path = tmp_path / "frame.h5"
+    frame.save_hdf5(h5_path)
+
+    loaded = stg.Frame(waterfall=h5_path)
+    assert loaded.waterfall is None
+    assert loaded.header is not None
+
+    loaded.copy()
+    pickle.dumps(loaded)
+
+    adapter = loaded.get_waterfall()
+    assert not hasattr(adapter.container, "h5")
+    assert loaded.check_waterfall() is adapter
+
+
+def test_waterfall_object_ingestion_does_not_mutate_source_h5(tmp_path):
+    frame = stg.Frame(shape=(4, 8), seed=0)
+    h5_path = tmp_path / "frame.h5"
+    frame.save_hdf5(h5_path)
+
+    waterfall = bl.Waterfall(str(h5_path))
+    try:
+        assert hasattr(waterfall.container, "h5")
+        loaded = stg.Frame(waterfall=waterfall)
+        assert loaded.waterfall is None
+        assert hasattr(waterfall.container, "h5")
+
+        sliced = loaded.get_slice(2, 6)
+        assert sliced.shape == (4, 4)
+        assert hasattr(waterfall.container, "h5")
+    finally:
+        waterfall.container.h5.close()

--- a/tests/test_frame_injection.py
+++ b/tests/test_frame_injection.py
@@ -11,6 +11,10 @@ def test_noise():
     frame = stg.Frame(shape=(16, 256), seed=0)
     frame.add_noise(0, 1, noise_type="gaussian")
     assert frame.get_noise_stats() == (0, 1)
+    assert frame.noise_stats.as_tuple() == (0, 1)
+
+    with pytest.raises(ValueError, match="method"):
+        stg.NoiseEstimationConfig(method="bad")
 
     gaussian_frame = stg.Frame(shape=(16, 256), seed=0)
     normal_frame = stg.Frame(shape=(16, 256), seed=0)
@@ -234,6 +238,9 @@ def test_injection_tools(tmp_path):
 
     frame.add_noise(1)
     assert frame.get_snr(intensity=100) == pytest.approx(4039.801975344831)
+    stats = frame.estimate_noise_stats()
+    intensity = frame.get_intensity(snr=10, noise_stats=stats)
+    assert frame.get_snr(intensity=intensity, noise_stats=stats) == pytest.approx(10)
     assert isinstance(frame.get_info(), dict)
 
     frame.add_constant_signal(frame.get_frequency(frame.fchans//2),

--- a/tests/test_frame_injection.py
+++ b/tests/test_frame_injection.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 
 from astropy import units as u
 import setigen as stg
+from setigen.noise import estimate_array_noise_stats
 
 
 def test_noise():
@@ -85,6 +86,26 @@ def test_noise():
                                  x_min_array=[0, 0],
                                  share_index=True,
                                  noise_type="gaussian")
+
+    for kwargs, match in [
+        ({"sigma": 0}, "sigma"),
+        ({"maxiters": 0}, "maxiters"),
+        ({"context_width": -1}, "context_width"),
+        ({"guard_width": -1}, "guard_width"),
+        ({"width_unit": "pixels"}, "width_unit"),
+        ({"combine": "per_time"}, "combine"),
+    ]:
+        with pytest.raises(ValueError, match=match):
+            stg.NoiseEstimationConfig(**kwargs)
+
+    with pytest.raises(ValueError, match="empty"):
+        estimate_array_noise_stats([])
+
+    robust = estimate_array_noise_stats([1, 2, 100],
+                                        config=stg.NoiseEstimationConfig(method="median_mad"))
+    assert robust.mean == 2
+    assert robust.std == pytest.approx(1.4826)
+    assert stg.NoiseStats(mean=0, std=1, n_samples=1, method="test").tchans is None
 
 
 def test_injection_options():

--- a/tests/test_frame_injection.py
+++ b/tests/test_frame_injection.py
@@ -161,6 +161,55 @@ def test_injection_options():
         frame.add_signal(path={"bad": "path"},
                          t_profile=1,
                          f_profile=stg.box_f_profile(width=frame.df))
+
+
+def test_constant_signal_doppler_smearing_handles_signed_and_zero_drift():
+    for drift_rate in [0, 1, -1]:
+        frame = stg.Frame(shape=(16, 256), seed=0)
+        frame.add_constant_signal(frame.get_frequency(frame.fchans // 2),
+                                  drift_rate=drift_rate * frame.unit_drift_rate,
+                                  level=1,
+                                  width=frame.df,
+                                  f_profile_type="box",
+                                  doppler_smearing=True)
+        assert np.max(frame.data) > 0
+
+    frame = stg.Frame(shape=(16, 256), seed=0)
+    with pytest.raises(ValueError, match="smearing_subsamples"):
+        frame.add_signal(path=frame.get_frequency(frame.fchans // 2),
+                         t_profile=1,
+                         f_profile=stg.box_f_profile(width=frame.df),
+                         doppler_smearing=True,
+                         smearing_subsamples=0)
+
+
+def test_add_signal_auto_bounding_for_known_profiles():
+    kwargs = dict(path=stg.constant_path(f_start=6e9, drift_rate=0),
+                  t_profile=1,
+                  f_profile=stg.box_f_profile(width=10))
+
+    full = stg.Frame(tchans=4, fchans=256, df=1, dt=1, fch1=6e9 + 128)
+    auto = stg.Frame(tchans=4, fchans=256, df=1, dt=1, fch1=6e9 + 128)
+    full.add_signal(**kwargs)
+    auto.add_signal(**kwargs, auto_bounding=True)
+    assert_allclose(auto.data, full.data)
+
+    full = stg.Frame(tchans=4, fchans=256, df=1, dt=1, fch1=6e9 + 128)
+    auto = stg.Frame(tchans=4, fchans=256, df=1, dt=1, fch1=6e9 + 128)
+    gaussian_kwargs = dict(path=stg.constant_path(f_start=6e9, drift_rate=0),
+                           t_profile=1,
+                           f_profile=stg.gaussian_f_profile(width=10))
+    full.add_signal(**gaussian_kwargs)
+    auto.add_signal(**gaussian_kwargs,
+                    auto_bounding=True,
+                    truncate_below=1e-3)
+    assert np.count_nonzero(auto.data) < np.count_nonzero(full.data)
+    assert np.max(auto.data) == pytest.approx(np.max(full.data))
+
+    with pytest.raises(ValueError, match="truncate_below"):
+        auto.add_signal(**gaussian_kwargs,
+                        auto_bounding=True,
+                        truncate_below=2)
     
 
 def test_injection_tools(tmp_path):

--- a/tests/test_voltage/test_reduction.py
+++ b/tests/test_voltage/test_reduction.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 from astropy import units as u
+from astropy.time import Time
 from blimpy import Waterfall
 
 import setigen as stg
@@ -698,6 +699,9 @@ def test_reduce_raw_to_frame_matches_existing_helper(tmp_path):
 
     assert frame.data.shape == helper.shape
     assert_allclose(frame.data, helper)
+    assert frame.header is not None
+    assert frame.source_name == frame.header["source_name"]
+    assert frame.t_start == pytest.approx(Time(frame.header["tstart"], format="mjd").unix)
 
 
 def test_reduce_raw_channel_subset_matches_full_coarse_slice(tmp_path):
@@ -845,6 +849,9 @@ def test_direct_spectrogram_matches_raw_roundtrip_total_power(tmp_path):
 
     assert direct_frame.data.shape == raw_frame.data.shape
     assert_allclose(direct_frame.data, raw_frame.data)
+    assert direct_frame.header is not None
+    assert direct_frame.source_name == direct_frame.header["source_name"]
+    assert direct_frame.t_start == pytest.approx(Time(direct_frame.header["tstart"], format="mjd").unix)
 
 
 def test_direct_spectrogram_cupy_backend_smoke():


### PR DESCRIPTION
## Summary

This branch adds file-backed spectrogram workflows to `Frame` so large `.fil` and HDF5 observations can be read, plotted, reduced, and injected into without materializing the full observation in memory.

Compared to `main`, the main changes are:

- Add private spectrogram backends for BL-style HDF5 and SIGPROC `.fil` files.
- Add `Frame.open(...)` for read-only file-backed access.
- Add `Frame.open_copy(...)` for safe copy-backed mutation.
- Add immediate file-backed `add_signal(...)` mutation in bounded time chunks.
- Preserve existing eager `Frame(waterfall=...)` behavior for memory-backed workflows.
- Add local noise/SNR estimation via `NoiseEstimationConfig` and `NoiseStats`.
- Add chunked file-backed `spectrum()` and `timeseries()` reductions for common `mean` / `sum` products.
- Add support metadata to built-in frequency profiles so `auto_bounding=True` can infer conservative render bounds.
- Update plotting and slicing paths so bounded file-backed reads work through the existing frame APIs.
- Add docs and plans covering file-backed injection, local SNR estimation, derived products, and future array-backend/GPU direction.

## Scientific / API Notes

The file-backed injection path keeps signal rendering bounds separate from local noise-estimation context. Tight render bounds minimize disk I/O, while local sigma-clipped noise windows provide a more appropriate SNR reference for real observations with bandpass structure, PFB scalloping, and local contamination.

File-backed mutation is immediate, not deferred: `add_signal()` patches the backing file before returning. The preferred safe workflow is `Frame.open_copy(...)`, which leaves the original observation unchanged.

Current limitations are documented:

- file-backed synthetic noise mutation is intentionally unsupported for now
- file-backed noise estimation currently uses rectangular local context
- path-aware chunked noise context and richer contamination diagnostics remain future work
- wideband/time-bounded signal models likely need a larger signal-model abstraction
